### PR TITLE
Latest python in Dockerfile & add docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.4
+FROM python:alpine
 
 RUN apk add --no-cache gettext
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  unobot:
+    container_name: unobot
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped


### PR DESCRIPTION
Easier to manage the docker container with compose.
Also the updated Dockerfile with new alpine and python version allows the project to be easily run on arm64 cpus.
The current python alpine release points to python 3.11, runs perfectly fine with mau_mau_bot.