### PR TITLE
feat: migrate to python-telegram-bot v22.7 with concurrency safety, forum support, and gameplay fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,8 @@ Flat structure — all Python source files in the project root. No packages.
 | Layer | Files |
 |-------|-------|
 | Game domain | `game.py`, `player.py`, `card.py`, `deck.py`, `errors.py` |
-| State management | `game_manager.py`, `shared_vars.py` |
+| State management | `game_manager.py`, `shared_vars.py`, `uno_update_processor.py` |
+| Result ID encoding | `result_id.py`, `result_id_resolver.py` |
 | Bot integration | `bot.py`, `actions.py`, `results.py`, `settings.py`, `simple_commands.py` |
 | Cross-cutting | `internationalization.py`, `utils.py`, `config.py`, `database.py`, `user_setting.py`, `promotions.py` |
 
@@ -36,15 +37,18 @@ with db_session:
     await send_async(bot, chat_id, text=us.lang)  # BAD: await inside session
 ```
 
-### Concurrency Model
-`concurrent_updates=True` is enabled. Two locking levels protect shared state:
+### Concurrency Model (UNO-12)
+Locking is **centralised** in `UnoUpdateProcessor` (subclass of `telegram.ext.BaseUpdateProcessor` in `uno_update_processor.py`). It serialises updates per `(chat_id, thread_id)` via an internal lock dict. Updates without a derivable chat context (plain `InlineQuery`, polls) run in parallel.
 
-- **`game.lock`** (`asyncio.Lock` per Game instance) — must be held for all game state mutations in `process_result`, `skip_player`, `skip_job`
-- **`gm.get_chat_lock(chat_id)`** (`asyncio.Lock` per chat) — must be held for GameManager operations (`new_game`, `join_game`, `leave_game`, `end_game`, `kick`)
+**Handlers must not acquire their own locks.** Do NOT add `async with chat_lock` / `async with game.lock` patterns — they were removed in UNO-12. A single game per `(chat_id, thread_id)` is guaranteed, so the update-level lock covers all handler state mutations.
 
-Lock ordering: always chat lock first, then game lock. Never reversed.
+Functions in `actions.py` (`do_skip`, `do_play_card`, `do_draw`, `do_call_bluff`) run inside the processor lock implicitly; no extra lock is needed.
 
-Functions in `actions.py` (`do_skip`, `do_play_card`, `do_draw`, `do_call_bluff`) expect the caller to already hold `game.lock`.
+### Singleton Games
+`GameManager.chatid_games` is keyed by `(chat_id, thread_id)` and holds **at most one** active `Game` per key. `GameManager.new_game(chat, thread_id=...)` raises `GameAlreadyRunningError` when the topic already has a game with joined players. Use `gm.game_for_chat_topic(chat_id, thread_id)` or `gm.game_by_id(game_id)` for lookups — never index by `chat.id` alone.
+
+### Inline Result IDs
+Every result ID produced in `reply_to_query` is re-encoded via `encode_results_list` (in `result_id.py`) as `<game_id>:<base_id>:<anti_cheat>`. Non-game sentinels (`nogame`, `hand`, `gameinfo`, `mode_*`) get the pseudo game-id `'none'`. `process_result` decodes via `decode_result_id` and resolves game/player via `resolve_result` (`result_id_resolver.py`); dead-game cases send a user-friendly DM.
 
 ### Locale Isolation
 `internationalization.py` uses `contextvars.ContextVar` for per-task locale stacks. The `@user_locale` and `@game_locales` decorators use `try/finally` to ensure cleanup. Job queue callbacks must explicitly set locales via `set_locale_stack()`.
@@ -53,17 +57,19 @@ Functions in `actions.py` (`do_skip`, `do_play_card`, `do_draw`, `do_call_bluff`
 Use `send_async()` from `utils.py` for all bot messages — it handles timeouts and error logging. Always pass `message_thread_id=game.thread_id` (or `update.message.message_thread_id` when no game context) to support forum topics.
 
 ### Game.owner
-`Game.owner` is an instance-level `list` initialized in `__init__`, NOT a class attribute. Do not move it to class level — mutable class attributes are shared across instances.
+`Game.owner` is an instance-level `list` initialised in `__init__`, NOT a class attribute. Do not move it to class level — mutable class attributes are shared across instances.
 
 ## Common Review Pitfalls
 
 - Missing `from pony.orm import db_session` when adding `with db_session:` blocks
 - Missing `message_thread_id` parameter on new `send_async` calls
-- Using `game.lock` without `async with` (must be `async with game.lock:`)
-- Accessing game state after releasing the lock (capture values inside the lock)
+- Re-introducing per-handler `async with chat_lock` / `async with game.lock` blocks — locking is owned by `UnoUpdateProcessor`
+- Indexing `GameManager.chatid_games` by `chat.id` alone — the key is `(chat.id, thread_id)`
+- Hand-rolling inline-result IDs — always go through `encode_results_list` / `decode_result_id`
+- Accessing game state across `await` boundaries in ways that assume old locking guarantees (e.g. capturing before dispatch) — still wise, even though the processor serialises per topic
 - Using `asyncio.get_event_loop()` (deprecated) — use `asyncio.get_running_loop()`
 - Forgetting `is_bot=False` in test `User()` constructors (required in v22)
 
 ## Testing
 
-`python -m pytest test/` — 24 tests covering game logic, concurrency locks, and locale isolation. Tests do NOT import `shared_vars.py` (which requires a valid bot token for `Application.builder()`).
+`python -m pytest test/` — covers game logic, UpdateProcessor serialisation, GameManager singleton enforcement, result-ID encoding/decoding, resolver dead-game cases, and locale isolation. Tests do NOT import `shared_vars.py` (which requires a valid bot token for `Application.builder()`).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,69 @@
+# Copilot Code Review Instructions
+
+## Project Overview
+
+Telegram bot for UNO (Mau Mau) in group chats via inline queries. Python 3.11+, python-telegram-bot v22.7 (async API), Pony ORM with SQLite.
+
+## Architecture
+
+Flat structure — all Python source files in the project root. No packages.
+
+| Layer | Files |
+|-------|-------|
+| Game domain | `game.py`, `player.py`, `card.py`, `deck.py`, `errors.py` |
+| State management | `game_manager.py`, `shared_vars.py` |
+| Bot integration | `bot.py`, `actions.py`, `results.py`, `settings.py`, `simple_commands.py` |
+| Cross-cutting | `internationalization.py`, `utils.py`, `config.py`, `database.py`, `user_setting.py`, `promotions.py` |
+
+## Critical Patterns to Enforce
+
+### Async Handlers
+All handler functions must be `async def`. All bot API calls must use `await`.
+
+### Pony ORM + async
+`@db_session` decorator must NOT be used on async functions. Use `with db_session:` blocks instead. Sessions must NOT span `await` calls — read data into local variables before awaiting.
+
+```python
+# CORRECT
+with db_session:
+    us = UserSetting.get(id=user.id)
+    lang = us.lang if us else 'en'
+await send_async(bot, chat_id, text=msg)
+
+# WRONG — db_session spanning await
+with db_session:
+    us = UserSetting.get(id=user.id)
+    await send_async(bot, chat_id, text=us.lang)  # BAD: await inside session
+```
+
+### Concurrency Model
+`concurrent_updates=True` is enabled. Two locking levels protect shared state:
+
+- **`game.lock`** (`asyncio.Lock` per Game instance) — must be held for all game state mutations in `process_result`, `skip_player`, `skip_job`
+- **`gm.get_chat_lock(chat_id)`** (`asyncio.Lock` per chat) — must be held for GameManager operations (`new_game`, `join_game`, `leave_game`, `end_game`, `kick`)
+
+Lock ordering: always chat lock first, then game lock. Never reversed.
+
+Functions in `actions.py` (`do_skip`, `do_play_card`, `do_draw`, `do_call_bluff`) expect the caller to already hold `game.lock`.
+
+### Locale Isolation
+`internationalization.py` uses `contextvars.ContextVar` for per-task locale stacks. The `@user_locale` and `@game_locales` decorators use `try/finally` to ensure cleanup. Job queue callbacks must explicitly set locales via `set_locale_stack()`.
+
+### Message Sending
+Use `send_async()` from `utils.py` for all bot messages — it handles timeouts and error logging. Always pass `message_thread_id=game.thread_id` (or `update.message.message_thread_id` when no game context) to support forum topics.
+
+### Game.owner
+`Game.owner` is an instance-level `list` initialized in `__init__`, NOT a class attribute. Do not move it to class level — mutable class attributes are shared across instances.
+
+## Common Review Pitfalls
+
+- Missing `from pony.orm import db_session` when adding `with db_session:` blocks
+- Missing `message_thread_id` parameter on new `send_async` calls
+- Using `game.lock` without `async with` (must be `async with game.lock:`)
+- Accessing game state after releasing the lock (capture values inside the lock)
+- Using `asyncio.get_event_loop()` (deprecated) — use `asyncio.get_running_loop()`
+- Forgetting `is_bot=False` in test `User()` constructors (required in v22)
+
+## Testing
+
+`python -m pytest test/` — 24 tests covering game logic, concurrency locks, and locale isolation. Tests do NOT import `shared_vars.py` (which requires a valid bot token for `Application.builder()`).

--- a/Pipfile
+++ b/Pipfile
@@ -7,8 +7,8 @@ verify_ssl = true
 telethon = "*"
 
 [packages]
-python-telegram-bot = "==13.15"
-pony = "*"
+python-telegram-bot = {version = "==22.7", extras = ["ext", "http2"]}
+pony = "==0.7.19"
 
 [requires]
 python_version = "3.11"

--- a/actions.py
+++ b/actions.py
@@ -30,7 +30,8 @@ class Countdown(object):
         self.locales = locales or []
 
 
-# Caller must hold the game lock
+# Per-(chat, thread) serialization is owned by UnoUpdateProcessor; callers
+# do not need to hold any lock.
 async def do_skip(bot, player, job_queue=None):
     game = player.game
     chat = game.chat
@@ -236,6 +237,8 @@ async def skip_job(context: ContextTypes.DEFAULT_TYPE):
     if game_is_running(game):
         set_locale_stack(context.job.data.locales)
         job_queue = context.job.data.job_queue
-        async with game.lock:
-            if game_is_running(game):
-                await do_skip(context.bot, player, job_queue)
+        # Job-queue runs outside the UpdateProcessor — no per-(chat, thread)
+        # lock is held here. The double game_is_running check still guards
+        # against the race where the player has already finished their turn.
+        if game_is_running(game):
+            await do_skip(context.bot, player, job_queue)

--- a/actions.py
+++ b/actions.py
@@ -6,12 +6,12 @@ import card as c
 from datetime import datetime
 
 from telegram import Message, Chat
-from telegram.ext import CallbackContext
+from telegram.ext import ContextTypes
 from apscheduler.jobstores.base import JobLookupError
 
 from config import TIME_REMOVAL_AFTER_SKIP, MIN_FAST_TURN_TIME
 from errors import DeckEmptyError, NotEnoughPlayersError
-from internationalization import __, _
+from internationalization import __, _, set_locale_stack
 from shared_vars import gm
 from user_setting import UserSetting
 from utils import send_async, display_name, game_is_running
@@ -21,14 +21,16 @@ logger = logging.getLogger(__name__)
 class Countdown(object):
     player = None
     job_queue = None
+    locales = None
 
-    def __init__(self, player, job_queue):
+    def __init__(self, player, job_queue, locales=None):
         self.player = player
         self.job_queue = job_queue
+        self.locales = locales or []
 
 
-# TODO do_skip() could get executed in another thread (it can be a job), so it looks like it can't use game.translate?
-def do_skip(bot, player, job_queue=None):
+# Caller must hold the game lock
+async def do_skip(bot, player, job_queue=None):
     game = player.game
     chat = game.chat
     skipped_player = game.current_player
@@ -46,7 +48,7 @@ def do_skip(bot, player, job_queue=None):
             pass
 
         n = skipped_player.waiting_time
-        send_async(bot, chat.id,
+        await send_async(bot, chat.id,
                    text=__("Waiting time to skip this player has "
                         "been reduced to {time} seconds.\n"
                         "Next player: {name}", multi=game.translate)
@@ -62,7 +64,7 @@ def do_skip(bot, player, job_queue=None):
     else:
         try:
             gm.leave_game(skipped_player.user, chat)
-            send_async(bot, chat.id,
+            await send_async(bot, chat.id,
                        text=__("{name1} ran out of time "
                             "and has been removed from the game!\n"
                             "Next player: {name2}", multi=game.translate)
@@ -74,17 +76,17 @@ def do_skip(bot, player, job_queue=None):
                 start_player_countdown(bot, game, job_queue)
 
         except NotEnoughPlayersError:
-            send_async(bot, chat.id,
+            await send_async(bot, chat.id,
                        text=__("{name} ran out of time "
                                "and has been removed from the game!\n"
                                "The game ended.", multi=game.translate)
                        .format(name=display_name(skipped_player.user)))
 
-            gm.end_game(chat, skipped_player.user)
+            await gm.end_game(chat, skipped_player.user)
 
 
 
-def do_play_card(bot, player, result_id):
+async def do_play_card(bot, player, result_id):
     """Plays the selected card and sends an update to the group if needed"""
     card = c.from_str(result_id)
     player.play(card)
@@ -100,13 +102,13 @@ def do_play_card(bot, player, result_id):
         us.cards_played += 1
 
     if game.choosing_color:
-        send_async(bot, chat.id, text=__("Please choose a color", multi=game.translate))
+        await send_async(bot, chat.id, text=__("Please choose a color", multi=game.translate))
 
     if len(player.cards) == 1:
-        send_async(bot, chat.id, text="UNO!")
+        await send_async(bot, chat.id, text="UNO!")
 
     if len(player.cards) == 0:
-        send_async(bot, chat.id,
+        await send_async(bot, chat.id,
                    text=__("{name} won!", multi=game.translate)
                    .format(name=user.first_name))
 
@@ -121,17 +123,17 @@ def do_play_card(bot, player, result_id):
         try:
             gm.leave_game(user, chat)
         except NotEnoughPlayersError:
-            send_async(bot, chat.id,
+            await send_async(bot, chat.id,
                        text=__("Game ended!", multi=game.translate))
 
             us2 = UserSetting.get(id=game.current_player.user.id)
             if us2 and us2.stats:
                 us2.games_played += 1
 
-            gm.end_game(chat, user)
+            await gm.end_game(chat, user)
 
 
-def do_draw(bot, player):
+async def do_draw(bot, player):
     """Does the drawing"""
     game = player.game
     draw_counter_before = game.draw_counter
@@ -139,7 +141,7 @@ def do_draw(bot, player):
     try:
         player.draw()
     except DeckEmptyError:
-        send_async(bot, player.game.chat.id,
+        await send_async(bot, player.game.chat.id,
                    text=__("There are no more cards in the deck.",
                            multi=game.translate))
 
@@ -149,13 +151,13 @@ def do_draw(bot, player):
         game.turn()
 
 
-def do_call_bluff(bot, player):
+async def do_call_bluff(bot, player):
     """Handles the bluff calling"""
     game = player.game
     chat = game.chat
 
     if player.prev.bluffing:
-        send_async(bot, chat.id,
+        await send_async(bot, chat.id,
                    text=__("Bluff called! Giving 4 cards to {name}",
                            multi=game.translate)
                    .format(name=player.prev.user.first_name))
@@ -163,13 +165,13 @@ def do_call_bluff(bot, player):
         try:
             player.prev.draw()
         except DeckEmptyError:
-            send_async(bot, player.game.chat.id,
+            await send_async(bot, player.game.chat.id,
                        text=__("There are no more cards in the deck.",
                                multi=game.translate))
 
     else:
         game.draw_counter += 2
-        send_async(bot, chat.id,
+        await send_async(bot, chat.id,
                    text=__("{name1} didn't bluff! Giving 6 cards to {name2}",
                            multi=game.translate)
                    .format(name1=player.prev.user.first_name,
@@ -177,7 +179,7 @@ def do_call_bluff(bot, player):
         try:
             player.draw()
         except DeckEmptyError:
-            send_async(bot, player.game.chat.id,
+            await send_async(bot, player.game.chat.id,
                        text=__("There are no more cards in the deck.",
                                multi=game.translate))
 
@@ -198,11 +200,13 @@ def start_player_countdown(bot, game, job_queue):
             except JobLookupError:
                 pass
 
+        from internationalization import _locale_stack
+        locales = _locale_stack.get([])
+
         job = job_queue.run_once(
-            #lambda x,y: do_skip(bot, player),
             skip_job,
             time,
-            context=Countdown(player, job_queue)
+            data=Countdown(player, job_queue, locales)
         )
 
         logger.info("Started countdown for player: {player}. {time} seconds."
@@ -210,9 +214,12 @@ def start_player_countdown(bot, game, job_queue):
         player.game.job = job
 
 
-def skip_job(context: CallbackContext):
-    player = context.job.context.player
+async def skip_job(context: ContextTypes.DEFAULT_TYPE):
+    player = context.job.data.player
     game = player.game
     if game_is_running(game):
-        job_queue = context.job.context.job_queue
-        do_skip(context.bot, player, job_queue)
+        set_locale_stack(context.job.data.locales)
+        job_queue = context.job.data.job_queue
+        async with game.lock:
+            if game_is_running(game):
+                await do_skip(context.bot, player, job_queue)

--- a/actions.py
+++ b/actions.py
@@ -10,6 +10,7 @@ from telegram.ext import ContextTypes
 from apscheduler.jobstores.base import JobLookupError
 
 from config import TIME_REMOVAL_AFTER_SKIP, MIN_FAST_TURN_TIME
+from pony.orm import db_session
 from errors import DeckEmptyError, NotEnoughPlayersError
 from internationalization import __, _, set_locale_stack
 from shared_vars import gm

--- a/actions.py
+++ b/actions.py
@@ -82,7 +82,7 @@ async def do_skip(bot, player, job_queue=None):
                                "The game ended.", multi=game.translate)
                        .format(name=display_name(skipped_player.user)))
 
-            await gm.end_game(chat, skipped_player.user)
+            gm.end_game(chat, skipped_player.user)
 
 
 
@@ -94,12 +94,13 @@ async def do_play_card(bot, player, result_id):
     chat = game.chat
     user = player.user
 
-    us = UserSetting.get(id=user.id)
-    if not us:
-        us = UserSetting(id=user.id)
+    with db_session:
+        us = UserSetting.get(id=user.id)
+        if not us:
+            us = UserSetting(id=user.id)
 
-    if us.stats:
-        us.cards_played += 1
+        if us.stats:
+            us.cards_played += 1
 
     if game.choosing_color:
         await send_async(bot, chat.id, text=__("Please choose a color", multi=game.translate))
@@ -112,11 +113,13 @@ async def do_play_card(bot, player, result_id):
                    text=__("{name} won!", multi=game.translate)
                    .format(name=user.first_name))
 
-        if us.stats:
-            us.games_played += 1
+        with db_session:
+            us = UserSetting.get(id=user.id)
+            if us and us.stats:
+                us.games_played += 1
 
-            if game.players_won == 0:
-                us.first_places += 1
+                if game.players_won == 0:
+                    us.first_places += 1
 
         game.players_won += 1
 
@@ -126,11 +129,12 @@ async def do_play_card(bot, player, result_id):
             await send_async(bot, chat.id,
                        text=__("Game ended!", multi=game.translate))
 
-            us2 = UserSetting.get(id=game.current_player.user.id)
-            if us2 and us2.stats:
-                us2.games_played += 1
+            with db_session:
+                us2 = UserSetting.get(id=game.current_player.user.id)
+                if us2 and us2.stats:
+                    us2.games_played += 1
 
-            await gm.end_game(chat, user)
+            gm.end_game(chat, user)
 
 
 async def do_draw(bot, player):

--- a/actions.py
+++ b/actions.py
@@ -53,8 +53,8 @@ async def do_skip(bot, player, job_queue=None):
                         "been reduced to {time} seconds.\n"
                         "Next player: {name}", multi=game.translate)
                    .format(time=n,
-                           name=display_name(next_player.user))
-        )
+                           name=display_name(next_player.user)),
+                   message_thread_id=game.thread_id)
         logger.info("{player} was skipped! "
                     .format(player=display_name(player.user)))
         game.turn()
@@ -69,7 +69,8 @@ async def do_skip(bot, player, job_queue=None):
                             "and has been removed from the game!\n"
                             "Next player: {name2}", multi=game.translate)
                        .format(name1=display_name(skipped_player.user),
-                               name2=display_name(next_player.user)))
+                               name2=display_name(next_player.user)),
+                       message_thread_id=game.thread_id)
             logger.info("{player} was skipped! "
                     .format(player=display_name(player.user)))
             if job_queue:
@@ -80,7 +81,8 @@ async def do_skip(bot, player, job_queue=None):
                        text=__("{name} ran out of time "
                                "and has been removed from the game!\n"
                                "The game ended.", multi=game.translate)
-                       .format(name=display_name(skipped_player.user)))
+                       .format(name=display_name(skipped_player.user)),
+                       message_thread_id=game.thread_id)
 
             gm.end_game(chat, skipped_player.user)
 
@@ -103,15 +105,18 @@ async def do_play_card(bot, player, result_id):
             us.cards_played += 1
 
     if game.choosing_color:
-        await send_async(bot, chat.id, text=__("Please choose a color", multi=game.translate))
+        await send_async(bot, chat.id, text=__("Please choose a color", multi=game.translate),
+                   message_thread_id=game.thread_id)
 
     if len(player.cards) == 1:
-        await send_async(bot, chat.id, text="UNO!")
+        await send_async(bot, chat.id, text="UNO!",
+                   message_thread_id=game.thread_id)
 
     if len(player.cards) == 0:
         await send_async(bot, chat.id,
                    text=__("{name} won!", multi=game.translate)
-                   .format(name=user.first_name))
+                   .format(name=user.first_name),
+                   message_thread_id=game.thread_id)
 
         with db_session:
             us = UserSetting.get(id=user.id)
@@ -127,7 +132,8 @@ async def do_play_card(bot, player, result_id):
             gm.leave_game(user, chat)
         except NotEnoughPlayersError:
             await send_async(bot, chat.id,
-                       text=__("Game ended!", multi=game.translate))
+                       text=__("Game ended!", multi=game.translate),
+                       message_thread_id=game.thread_id)
 
             with db_session:
                 us2 = UserSetting.get(id=game.current_player.user.id)
@@ -147,7 +153,8 @@ async def do_draw(bot, player):
     except DeckEmptyError:
         await send_async(bot, player.game.chat.id,
                    text=__("There are no more cards in the deck.",
-                           multi=game.translate))
+                           multi=game.translate),
+                   message_thread_id=game.thread_id)
 
     if (game.last_card.value == c.DRAW_TWO or
         game.last_card.special == c.DRAW_FOUR) and \
@@ -164,14 +171,16 @@ async def do_call_bluff(bot, player):
         await send_async(bot, chat.id,
                    text=__("Bluff called! Giving 4 cards to {name}",
                            multi=game.translate)
-                   .format(name=player.prev.user.first_name))
+                   .format(name=player.prev.user.first_name),
+                   message_thread_id=game.thread_id)
 
         try:
             player.prev.draw()
         except DeckEmptyError:
             await send_async(bot, player.game.chat.id,
                        text=__("There are no more cards in the deck.",
-                               multi=game.translate))
+                               multi=game.translate),
+                       message_thread_id=game.thread_id)
 
     else:
         game.draw_counter += 2
@@ -179,13 +188,15 @@ async def do_call_bluff(bot, player):
                    text=__("{name1} didn't bluff! Giving 6 cards to {name2}",
                            multi=game.translate)
                    .format(name1=player.prev.user.first_name,
-                           name2=player.user.first_name))
+                           name2=player.user.first_name),
+                   message_thread_id=game.thread_id)
         try:
             player.draw()
         except DeckEmptyError:
             await send_async(bot, player.game.chat.id,
                        text=__("There are no more cards in the deck.",
-                               multi=game.translate))
+                               multi=game.translate),
+                       message_thread_id=game.thread_id)
 
     game.turn()
 

--- a/actions.py
+++ b/actions.py
@@ -12,7 +12,7 @@ from apscheduler.jobstores.base import JobLookupError
 from config import TIME_REMOVAL_AFTER_SKIP, MIN_FAST_TURN_TIME
 from pony.orm import db_session
 from errors import DeckEmptyError, NotEnoughPlayersError
-from internationalization import __, _, set_locale_stack
+from internationalization import __, _, locale_stack
 from shared_vars import gm
 from user_setting import UserSetting
 from utils import send_async, display_name, game_is_running
@@ -244,7 +244,6 @@ async def skip_job(context: ContextTypes.DEFAULT_TYPE):
     if not game_is_running(game):
         return
 
-    set_locale_stack(context.job.data.locales)
     job_queue = context.job.data.job_queue
 
     # Late-import to avoid circular imports at module load.
@@ -252,5 +251,7 @@ async def skip_job(context: ContextTypes.DEFAULT_TYPE):
     key = (game.chat.id, game.thread_id)
     async with update_processor.lock_for_key(key):
         # Re-check inside the lock — the game may have ended while we waited.
-        if game_is_running(game):
+        if not game_is_running(game):
+            return
+        with locale_stack(context.job.data.locales):
             await do_skip(context.bot, player, job_queue)

--- a/actions.py
+++ b/actions.py
@@ -65,7 +65,7 @@ async def do_skip(bot, player, job_queue=None):
 
     else:
         try:
-            gm.leave_game(skipped_player.user, chat)
+            gm.leave_game(skipped_player.user, chat, thread_id=game.thread_id)
             await send_async(bot, chat.id,
                        text=__("{name1} ran out of time "
                             "and has been removed from the game!\n"
@@ -131,7 +131,7 @@ async def do_play_card(bot, player, result_id):
         game.players_won += 1
 
         try:
-            gm.leave_game(user, chat)
+            gm.leave_game(user, chat, thread_id=game.thread_id)
         except NotEnoughPlayersError:
             await send_async(bot, chat.id,
                        text=__("Game ended!", multi=game.translate),

--- a/actions.py
+++ b/actions.py
@@ -232,13 +232,25 @@ def start_player_countdown(bot, game, job_queue):
 
 
 async def skip_job(context: ContextTypes.DEFAULT_TYPE):
+    """Job-queue callback fired when a player's turn timer elapses.
+
+    Runs outside the :class:`UnoUpdateProcessor`'s normal dispatch path, so
+    we have to acquire the same per-``(chat, thread_id)`` lock manually to
+    avoid racing with an inline update that the user might still send right
+    before the timer fires.
+    """
     player = context.job.data.player
     game = player.game
-    if game_is_running(game):
-        set_locale_stack(context.job.data.locales)
-        job_queue = context.job.data.job_queue
-        # Job-queue runs outside the UpdateProcessor — no per-(chat, thread)
-        # lock is held here. The double game_is_running check still guards
-        # against the race where the player has already finished their turn.
+    if not game_is_running(game):
+        return
+
+    set_locale_stack(context.job.data.locales)
+    job_queue = context.job.data.job_queue
+
+    # Late-import to avoid circular imports at module load.
+    from shared_vars import update_processor
+    key = (game.chat.id, game.thread_id)
+    async with update_processor.lock_for_key(key):
+        # Re-check inside the lock — the game may have ended while we waited.
         if game_is_running(game):
             await do_skip(context.bot, player, job_queue)

--- a/bot.py
+++ b/bot.py
@@ -51,6 +51,14 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 logging.getLogger('apscheduler').setLevel(logging.WARNING)
 
+
+def get_thread_id(update):
+    """Extract message_thread_id from an update, or None"""
+    if update.message:
+        return update.message.message_thread_id
+    return None
+
+
 @user_locale
 async def notify_me(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for /notify_me command, pm people for next game"""
@@ -71,6 +79,7 @@ async def notify_me(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def new_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /new command"""
     chat_id = update.message.chat_id
+    thread_id = get_thread_id(update)
 
     if update.message.chat.type == 'private':
         await help_handler(update, context)
@@ -91,10 +100,12 @@ async def new_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
             game.starter = update.message.from_user
             game.owner.append(update.message.from_user.id)
             game.mode = DEFAULT_GAMEMODE
+            game.thread_id = thread_id
 
         await send_async(context.bot, chat_id,
                    text=_("Created a new game! Join the game with /join "
-                          "and start the game with /start"))
+                          "and start the game with /start"),
+                   message_thread_id=thread_id)
 
 
 @user_locale
@@ -110,7 +121,8 @@ async def kill_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if not games:
             await send_async(context.bot, chat.id,
-                       text=_("There is no running game in this chat."))
+                       text=_("There is no running game in this chat."),
+                       message_thread_id=get_thread_id(update))
             return
 
     game = games[-1]
@@ -120,24 +132,28 @@ async def kill_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
         async with chat_lock:
             try:
                 gm.end_game(chat, user)
-                await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
+                await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate),
+                           message_thread_id=game.thread_id)
 
             except NoGameInChatError:
                 await send_async(context.bot, chat.id,
                            text=_("The game is not started yet. "
                                   "Join the game with /join and start the game with /start"),
-                           reply_to_message_id=update.message.message_id)
+                           reply_to_message_id=update.message.message_id,
+                           message_thread_id=game.thread_id)
 
     else:
         await send_async(context.bot, chat.id,
                   text=_("Only the game creator ({name}) and admin can do that.")
                   .format(name=game.starter.first_name),
-                  reply_to_message_id=update.message.message_id)
+                  reply_to_message_id=update.message.message_id,
+                  message_thread_id=game.thread_id)
 
 @user_locale
 async def join_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /join command"""
     chat = update.message.chat
+    thread_id = get_thread_id(update)
 
     if update.message.chat.type == 'private':
         await help_handler(update, context)
@@ -149,33 +165,38 @@ async def join_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
             gm.join_game(update.message.from_user, chat)
 
         except LobbyClosedError:
-                await send_async(context.bot, chat.id, text=_("The lobby is closed"))
+                await send_async(context.bot, chat.id, text=_("The lobby is closed"),
+                           message_thread_id=thread_id)
                 return
 
         except NoGameInChatError:
             await send_async(context.bot, chat.id,
                        text=_("No game is running at the moment. "
                               "Create a new game with /new"),
-                       reply_to_message_id=update.message.message_id)
+                       reply_to_message_id=update.message.message_id,
+                       message_thread_id=thread_id)
             return
 
         except AlreadyJoinedError:
             await send_async(context.bot, chat.id,
                        text=_("You already joined the game. Start the game "
                               "with /start"),
-                       reply_to_message_id=update.message.message_id)
+                       reply_to_message_id=update.message.message_id,
+                       message_thread_id=thread_id)
             return
 
         except DeckEmptyError:
             await send_async(context.bot, chat.id,
                        text=_("There are not enough cards left in the deck for "
                               "new players to join."),
-                       reply_to_message_id=update.message.message_id)
+                       reply_to_message_id=update.message.message_id,
+                       message_thread_id=thread_id)
             return
 
     await send_async(context.bot, chat.id,
                text=_("Joined the game"),
-               reply_to_message_id=update.message.message_id)
+               reply_to_message_id=update.message.message_id,
+               message_thread_id=thread_id)
 
 
 @user_locale
@@ -189,7 +210,8 @@ async def leave_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if player is None:
         await send_async(context.bot, chat.id, text=_("You are not playing in a game in "
                                         "this group."),
-                   reply_to_message_id=update.message.message_id)
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=get_thread_id(update))
         return
 
     game = player.game
@@ -202,12 +224,14 @@ async def leave_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
         except NoGameInChatError:
             await send_async(context.bot, chat.id, text=_("You are not playing in a game in "
                                             "this group."),
-                       reply_to_message_id=update.message.message_id)
+                       reply_to_message_id=update.message.message_id,
+                       message_thread_id=game.thread_id)
             return
 
         except NotEnoughPlayersError:
             gm.end_game(chat, user)
-            await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
+            await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate),
+                       message_thread_id=game.thread_id)
             return
 
     if game.started:
@@ -215,13 +239,15 @@ async def leave_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
                    text=__("Okay. Next Player: {name}",
                            multi=game.translate).format(
                        name=display_name(game.current_player.user)),
-                   reply_to_message_id=update.message.message_id)
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id)
     else:
         await send_async(context.bot, chat.id,
                    text=__("{name} left the game before it started.",
                            multi=game.translate).format(
                        name=display_name(user)),
-                   reply_to_message_id=update.message.message_id)
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id)
 
 
 @user_locale
@@ -242,14 +268,16 @@ async def kick_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await send_async(context.bot, chat.id,
                    text=_("No game is running at the moment. "
                           "Create a new game with /new"),
-                   reply_to_message_id=update.message.message_id)
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=get_thread_id(update))
             return
 
     if not game.started:
         await send_async(context.bot, chat.id,
                    text=_("The game is not started yet. "
                           "Join the game with /join and start the game with /start"),
-                   reply_to_message_id=update.message.message_id)
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id)
         return
 
     if await user_is_creator_or_admin(user, game, context.bot, chat):
@@ -264,36 +292,43 @@ async def kick_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
                 except NoGameInChatError:
                     await send_async(context.bot, chat.id, text=_("Player {name} is not found in the current game.".format(name=display_name(kicked))),
-                                    reply_to_message_id=update.message.message_id)
+                                    reply_to_message_id=update.message.message_id,
+                                    message_thread_id=game.thread_id)
                     return
 
                 except NotEnoughPlayersError:
                     gm.end_game(chat, user)
                     await send_async(context.bot, chat.id,
-                                    text=_("{0} was kicked by {1}".format(display_name(kicked), display_name(user))))
-                    await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
+                                    text=_("{0} was kicked by {1}".format(display_name(kicked), display_name(user))),
+                                    message_thread_id=game.thread_id)
+                    await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate),
+                                    message_thread_id=game.thread_id)
                     return
 
             await send_async(context.bot, chat.id,
-                            text=_("{0} was kicked by {1}".format(display_name(kicked), display_name(user))))
+                            text=_("{0} was kicked by {1}".format(display_name(kicked), display_name(user))),
+                            message_thread_id=game.thread_id)
 
         else:
             await send_async(context.bot, chat.id,
                 text=_("Please reply to the person you want to kick and type /kick again."),
-                reply_to_message_id=update.message.message_id)
+                reply_to_message_id=update.message.message_id,
+                message_thread_id=game.thread_id)
             return
 
         await send_async(context.bot, chat.id,
                    text=__("Okay. Next Player: {name}",
                            multi=game.translate).format(
                        name=display_name(game.current_player.user)),
-                   reply_to_message_id=update.message.message_id)
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id)
 
     else:
         await send_async(context.bot, chat.id,
                   text=_("Only the game creator ({name}) and admin can do that.")
                   .format(name=game.starter.first_name),
-                  reply_to_message_id=update.message.message_id)
+                  reply_to_message_id=update.message.message_id,
+                  message_thread_id=game.thread_id)
 
 
 async def select_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -353,12 +388,14 @@ async def status_update(update: Update, context: ContextTypes.DEFAULT_TYPE):
             except NotEnoughPlayersError:
                 gm.end_game(chat, user)
                 await send_async(context.bot, chat.id, text=__("Game ended!",
-                                                 multi=game.translate))
+                                                 multi=game.translate),
+                           message_thread_id=game.thread_id)
                 return
 
         await send_async(context.bot, chat.id, text=__("Removing {name} from the game",
                                          multi=game.translate)
-                   .format(name=display_name(user)))
+                   .format(name=display_name(user)),
+                   message_thread_id=game.thread_id)
 
 
 @game_locales
@@ -368,22 +405,26 @@ async def start_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if update.message.chat.type != 'private':
         chat = update.message.chat
+        thread_id = get_thread_id(update)
 
         try:
             game = gm.chatid_games[chat.id][-1]
         except (KeyError, IndexError):
             await send_async(context.bot, chat.id,
                        text=_("There is no game running in this chat. Create "
-                              "a new one with /new"))
+                              "a new one with /new"),
+                       message_thread_id=thread_id)
             return
 
         if game.started:
-            await send_async(context.bot, chat.id, text=_("The game has already started"))
+            await send_async(context.bot, chat.id, text=_("The game has already started"),
+                       message_thread_id=game.thread_id)
 
         elif len(game.players) < MIN_PLAYERS:
             await send_async(context.bot, chat.id,
                        text=__("At least {minplayers} players must /join the game "
-                              "before you can start it").format(minplayers=MIN_PLAYERS))
+                              "before you can start it").format(minplayers=MIN_PLAYERS),
+                       message_thread_id=game.thread_id)
 
         else:
             # Starting a game
@@ -404,12 +445,14 @@ async def start_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
             await context.bot.send_sticker(chat.id,
                             sticker=c.STICKERS[str(game.last_card)],
-                            read_timeout=TIMEOUT, write_timeout=TIMEOUT)
+                            read_timeout=TIMEOUT, write_timeout=TIMEOUT,
+                            message_thread_id=game.thread_id)
 
             await context.bot.send_message(chat.id,
                             text=first_message,
                             reply_markup=InlineKeyboardMarkup(choice),
-                            read_timeout=TIMEOUT, write_timeout=TIMEOUT)
+                            read_timeout=TIMEOUT, write_timeout=TIMEOUT,
+                            message_thread_id=game.thread_id)
 
             start_player_countdown(context.bot, game, context.job_queue)
 
@@ -445,7 +488,8 @@ async def close_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if not games:
         await send_async(context.bot, chat.id,
-                   text=_("There is no running game in this chat."))
+                   text=_("There is no running game in this chat."),
+                   message_thread_id=get_thread_id(update))
         return
 
     game = games[-1]
@@ -453,14 +497,16 @@ async def close_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if user.id in game.owner:
         game.open = False
         await send_async(context.bot, chat.id, text=_("Closed the lobby. "
-                                        "No more players can join this game."))
+                                        "No more players can join this game."),
+                   message_thread_id=game.thread_id)
         return
 
     else:
         await send_async(context.bot, chat.id,
                    text=_("Only the game creator ({name}) and admin can do that.")
                    .format(name=game.starter.first_name),
-                   reply_to_message_id=update.message.message_id)
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id)
         return
 
 
@@ -473,7 +519,8 @@ async def open_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if not games:
         await send_async(context.bot, chat.id,
-                   text=_("There is no running game in this chat."))
+                   text=_("There is no running game in this chat."),
+                   message_thread_id=get_thread_id(update))
         return
 
     game = games[-1]
@@ -481,13 +528,15 @@ async def open_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if user.id in game.owner:
         game.open = True
         await send_async(context.bot, chat.id, text=_("Opened the lobby. "
-                                        "New players may /join the game."))
+                                        "New players may /join the game."),
+                   message_thread_id=game.thread_id)
         return
     else:
         await send_async(context.bot, chat.id,
                    text=_("Only the game creator ({name}) and admin can do that.")
                    .format(name=game.starter.first_name),
-                   reply_to_message_id=update.message.message_id)
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id)
         return
 
 
@@ -500,7 +549,8 @@ async def enable_translations(update: Update, context: ContextTypes.DEFAULT_TYPE
 
     if not games:
         await send_async(context.bot, chat.id,
-                   text=_("There is no running game in this chat."))
+                   text=_("There is no running game in this chat."),
+                   message_thread_id=get_thread_id(update))
         return
 
     game = games[-1]
@@ -508,14 +558,16 @@ async def enable_translations(update: Update, context: ContextTypes.DEFAULT_TYPE
     if user.id in game.owner:
         game.translate = True
         await send_async(context.bot, chat.id, text=_("Enabled multi-translations. "
-                                        "Disable with /disable_translations"))
+                                        "Disable with /disable_translations"),
+                   message_thread_id=game.thread_id)
         return
 
     else:
         await send_async(context.bot, chat.id,
                    text=_("Only the game creator ({name}) and admin can do that.")
                    .format(name=game.starter.first_name),
-                   reply_to_message_id=update.message.message_id)
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id)
         return
 
 
@@ -528,7 +580,8 @@ async def disable_translations(update: Update, context: ContextTypes.DEFAULT_TYP
 
     if not games:
         await send_async(context.bot, chat.id,
-                   text=_("There is no running game in this chat."))
+                   text=_("There is no running game in this chat."),
+                   message_thread_id=get_thread_id(update))
         return
 
     game = games[-1]
@@ -537,14 +590,16 @@ async def disable_translations(update: Update, context: ContextTypes.DEFAULT_TYP
         game.translate = False
         await send_async(context.bot, chat.id, text=_("Disabled multi-translations. "
                                         "Enable them again with "
-                                        "/enable_translations"))
+                                        "/enable_translations"),
+                   message_thread_id=game.thread_id)
         return
 
     else:
         await send_async(context.bot, chat.id,
                    text=_("Only the game creator ({name}) and admin can do that.")
                    .format(name=game.starter.first_name),
-                   reply_to_message_id=update.message.message_id)
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id)
         return
 
 
@@ -558,7 +613,8 @@ async def skip_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
     player = gm.player_for_user_in_chat(user, chat)
     if not player:
         await send_async(context.bot, chat.id,
-                   text=_("You are not playing in a game in this chat."))
+                   text=_("You are not playing in a game in this chat."),
+                   message_thread_id=get_thread_id(update))
         return
 
     game = player.game
@@ -577,7 +633,8 @@ async def skip_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
                           "Please wait {time} seconds",
                           n)
                    .format(time=n),
-                   reply_to_message_id=update.message.message_id)
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id)
     else:
         async with game.lock:
             await do_skip(context.bot, player)
@@ -684,7 +741,8 @@ async def process_result(update: Update, context: ContextTypes.DEFAULT_TYPE):
         mode = result_id[5:]
         game.set_mode(mode)
         logger.info("Gamemode changed to {mode}".format(mode = mode))
-        await send_async(context.bot, chat.id, text=__("Gamemode changed to {mode}".format(mode = mode)))
+        await send_async(context.bot, chat.id, text=__("Gamemode changed to {mode}".format(mode = mode)),
+                   message_thread_id=game.thread_id)
         return
     elif len(result_id) == 36:  # UUID result
         return
@@ -693,7 +751,8 @@ async def process_result(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if int(anti_cheat) != player.anti_cheat:
             await send_async(context.bot, chat.id,
                        text=__("Cheat attempt by {name}", multi=game.translate)
-                       .format(name=display_name(player.user)))
+                       .format(name=display_name(player.user)),
+                       message_thread_id=game.thread_id)
             return
 
         player.anti_cheat += 1
@@ -719,7 +778,8 @@ async def process_result(update: Update, context: ContextTypes.DEFAULT_TYPE):
         choice = [[InlineKeyboardButton(text=_("Make your choice!"), switch_inline_query_current_chat='')]]
         await send_async(context.bot, chat.id,
                         text=nextplayer_message,
-                        reply_markup=InlineKeyboardMarkup(choice))
+                        reply_markup=InlineKeyboardMarkup(choice),
+                        message_thread_id=game.thread_id)
         start_player_countdown(context.bot, game, context.job_queue)
 
 

--- a/bot.py
+++ b/bot.py
@@ -334,7 +334,10 @@ async def kick_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def select_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for callback queries to select the current game"""
 
-    chat_id = int(update.callback_query.data)
+    try:
+        chat_id = int(update.callback_query.data)
+    except (ValueError, TypeError):
+        return
     user_id = update.callback_query.from_user.id
     players = gm.userid_players[user_id]
     for player in players:
@@ -739,6 +742,8 @@ async def process_result(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif result_id.startswith('mode_'):
         # First 5 characters are 'mode_', the rest is the gamemode.
         mode = result_id[5:]
+        if mode not in ('classic', 'fast', 'wild', 'text'):
+            return
         game.set_mode(mode)
         logger.info("Gamemode changed to {mode}".format(mode = mode))
         await send_async(context.bot, chat.id, text=__("Gamemode changed to {mode}".format(mode = mode)),

--- a/bot.py
+++ b/bot.py
@@ -85,22 +85,26 @@ async def new_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await help_handler(update, context)
 
     else:
+        # Collect reminders before locking (send after lock release)
+        remind_users = None
+        if update.message.chat_id in gm.remind_dict:
+            remind_users = list(gm.remind_dict[update.message.chat_id])
+            del gm.remind_dict[update.message.chat_id]
+
         chat_lock = gm.get_chat_lock(chat_id)
         async with chat_lock:
-            if update.message.chat_id in gm.remind_dict:
-                for user in gm.remind_dict[update.message.chat_id]:
-                    await send_async(context.bot,
-                               user,
-                               text=_("A new game has been started in {title}").format(
-                                    title=update.message.chat.title))
-
-                del gm.remind_dict[update.message.chat_id]
-
             game = gm.new_game(update.message.chat)
             game.starter = update.message.from_user
             game.owner.append(update.message.from_user.id)
             game.mode = DEFAULT_GAMEMODE
             game.thread_id = thread_id
+
+        if remind_users:
+            for user in remind_users:
+                await send_async(context.bot,
+                           user,
+                           text=_("A new game has been started in {title}").format(
+                                title=update.message.chat.title))
 
         await send_async(context.bot, chat_id,
                    text=_("Created a new game! Join the game with /join "
@@ -806,9 +810,7 @@ async def process_result(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 def reset_waiting_time(bot, player):
-    """Resets waiting time for a player and sends a notice to the group"""
-    chat = player.game.chat
-
+    """Resets waiting time for a player"""
     if player.waiting_time < WAITING_TIME:
         player.waiting_time = WAITING_TIME
 

--- a/bot.py
+++ b/bot.py
@@ -165,8 +165,9 @@ async def join_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
             gm.join_game(update.message.from_user, chat)
 
         except LobbyClosedError:
+                game = gm.chatid_games.get(chat.id, [None])[-1]
                 await send_async(context.bot, chat.id, text=_("The lobby is closed"),
-                           message_thread_id=thread_id)
+                           message_thread_id=game.thread_id if game else thread_id)
                 return
 
         except NoGameInChatError:
@@ -178,25 +179,30 @@ async def join_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return
 
         except AlreadyJoinedError:
+            game = gm.chatid_games.get(chat.id, [None])[-1]
             await send_async(context.bot, chat.id,
                        text=_("You already joined the game. Start the game "
                               "with /start"),
                        reply_to_message_id=update.message.message_id,
-                       message_thread_id=thread_id)
+                       message_thread_id=game.thread_id if game else thread_id)
             return
 
         except DeckEmptyError:
+            game = gm.chatid_games.get(chat.id, [None])[-1]
             await send_async(context.bot, chat.id,
                        text=_("There are not enough cards left in the deck for "
                               "new players to join."),
                        reply_to_message_id=update.message.message_id,
-                       message_thread_id=thread_id)
+                       message_thread_id=game.thread_id if game else thread_id)
             return
 
+    # Success — get the game the player just joined
+    player = gm.player_for_user_in_chat(update.message.from_user, chat)
+    game_thread = player.game.thread_id if player else thread_id
     await send_async(context.bot, chat.id,
                text=_("Joined the game"),
                reply_to_message_id=update.message.message_id,
-               message_thread_id=thread_id)
+               message_thread_id=game_thread)
 
 
 @user_locale
@@ -700,7 +706,12 @@ async def reply_to_query(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
                 add_gameinfo(game, results)
 
-        elif user_id != game.current_player.user.id or not game.started:
+        elif user_id != game.current_player.user.id:
+            # Not the current player — show cards as not playable.
+            # Defensive: if draw_counter > 0 and this player is next,
+            # the turn may still be transitioning — show draw option.
+            if game.draw_counter and game.current_player.next.user.id == user_id:
+                add_draw(player, results)
             for card in sorted(player.cards):
                 add_card(game, card, results, can_play=False)
 
@@ -827,7 +838,13 @@ application.add_error_handler(error)
 
 
 async def post_init(application):
-    """Set bot commands on startup so Telegram clients show them"""
+    """Set bot commands and validate configuration on startup"""
+    me = await application.bot.get_me()
+    if not me.supports_inline_queries:
+        logger.warning("Inline mode is NOT enabled for @%s. "
+                       "Players will not be able to select cards. "
+                       "Enable it via @BotFather /setinline.", me.username)
+
     await application.bot.set_my_commands([
         BotCommand('new', 'Start a new game'),
         BotCommand('join', 'Join the current game'),

--- a/bot.py
+++ b/bot.py
@@ -31,9 +31,12 @@ import settings
 import simple_commands
 from actions import do_skip, do_play_card, do_draw, do_call_bluff, start_player_countdown
 from config import WAITING_TIME, DEFAULT_GAMEMODE, MIN_PLAYERS
-from errors import (NoGameInChatError, LobbyClosedError, AlreadyJoinedError,
-                    NotEnoughPlayersError, DeckEmptyError)
+from errors import (AlreadyJoinedError, DeckEmptyError, GameAlreadyRunningError,
+                    LobbyClosedError, NoGameInChatError, NotEnoughPlayersError)
 from internationalization import _, __, user_locale, game_locales
+from result_id import (PSEUDO_GAME_ID, decode_result_id, encode_results_list)
+from result_id_resolver import (DEAD_NO_CURRENT_GAME, DEAD_NOT_A_PLAYER,
+                                DEAD_UNKNOWN_GAME, resolve_result)
 from results import (add_call_bluff, add_choose_color, add_draw, add_gameinfo,
                      add_no_game, add_not_started, add_other_cards, add_pass,
                      add_card, add_mode_classic, add_mode_fast, add_mode_wild, add_mode_text)
@@ -57,6 +60,26 @@ def get_thread_id(update):
     if update.message:
         return update.message.message_thread_id
     return None
+
+
+def _game_in_chat(chat_id, thread_id):
+    """Resolve the active game in this (chat, thread). Falls back to any game
+    in the same chat when thread_id is None — this preserves previous UX where
+    /kill from the General channel could close a topic-bound game."""
+    game = gm.game_for_chat_topic(chat_id, thread_id)
+    if game is not None:
+        return game
+    if thread_id is None:
+        return gm._any_game_in_chat(chat_id)
+    return None
+
+
+def _resolve_game_id(game_id):
+    """Resolver for UnoUpdateProcessor: maps game.id back to (chat_id, thread_id)."""
+    game = gm.game_by_id(game_id)
+    if game is None:
+        return None
+    return (game.chat.id, game.thread_id)
 
 
 @user_locale
@@ -91,13 +114,17 @@ async def new_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
             remind_users = list(gm.remind_dict[update.message.chat_id])
             del gm.remind_dict[update.message.chat_id]
 
-        chat_lock = gm.get_chat_lock(chat_id)
-        async with chat_lock:
-            game = gm.new_game(update.message.chat)
-            game.starter = update.message.from_user
-            game.owner.append(update.message.from_user.id)
-            game.mode = DEFAULT_GAMEMODE
-            game.thread_id = thread_id
+        try:
+            game = gm.new_game(update.message.chat, thread_id=thread_id)
+        except GameAlreadyRunningError:
+            await send_async(context.bot, chat_id,
+                       text=_("There is already a game in this chat. "
+                              "End it with /kill before starting a new one."),
+                       message_thread_id=thread_id)
+            return
+        game.starter = update.message.from_user
+        game.owner.append(update.message.from_user.id)
+        game.mode = DEFAULT_GAMEMODE
 
         if remind_users:
             for user in remind_users:
@@ -117,34 +144,31 @@ async def kill_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /kill command"""
     chat = update.message.chat
     user = update.message.from_user
-    games = gm.chatid_games.get(chat.id)
+    thread_id = get_thread_id(update)
+    game = _game_in_chat(chat.id, thread_id)
 
     if update.message.chat.type == 'private':
         await help_handler(update, context)
         return
 
-    if not games:
-            await send_async(context.bot, chat.id,
-                       text=_("There is no running game in this chat."),
-                       message_thread_id=get_thread_id(update))
-            return
-
-    game = games[-1]
+    if game is None:
+        await send_async(context.bot, chat.id,
+                   text=_("There is no running game in this chat."),
+                   message_thread_id=thread_id)
+        return
 
     if await user_is_creator_or_admin(user, game, context.bot, chat):
-        chat_lock = gm.get_chat_lock(chat.id)
-        async with chat_lock:
-            try:
-                gm.end_game(chat, user)
-                await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate),
-                           message_thread_id=game.thread_id)
+        try:
+            gm.end_game(chat, user)
+            await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate),
+                       message_thread_id=game.thread_id)
 
-            except NoGameInChatError:
-                await send_async(context.bot, chat.id,
-                           text=_("The game is not started yet. "
-                                  "Join the game with /join and start the game with /start"),
-                           reply_to_message_id=update.message.message_id,
-                           message_thread_id=game.thread_id)
+        except NoGameInChatError:
+            await send_async(context.bot, chat.id,
+                       text=_("The game is not started yet. "
+                              "Join the game with /join and start the game with /start"),
+                       reply_to_message_id=update.message.message_id,
+                       message_thread_id=game.thread_id)
 
     else:
         await send_async(context.bot, chat.id,
@@ -163,42 +187,40 @@ async def join_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await help_handler(update, context)
         return
 
-    chat_lock = gm.get_chat_lock(chat.id)
-    async with chat_lock:
-        try:
-            gm.join_game(update.message.from_user, chat)
+    try:
+        gm.join_game(update.message.from_user, chat, thread_id=thread_id)
 
-        except LobbyClosedError:
-                game = gm.chatid_games.get(chat.id, [None])[-1]
-                await send_async(context.bot, chat.id, text=_("The lobby is closed"),
-                           message_thread_id=game.thread_id if game else thread_id)
-                return
+    except LobbyClosedError:
+        game = _game_in_chat(chat.id, thread_id)
+        await send_async(context.bot, chat.id, text=_("The lobby is closed"),
+                   message_thread_id=game.thread_id if game else thread_id)
+        return
 
-        except NoGameInChatError:
-            await send_async(context.bot, chat.id,
-                       text=_("No game is running at the moment. "
-                              "Create a new game with /new"),
-                       reply_to_message_id=update.message.message_id,
-                       message_thread_id=thread_id)
-            return
+    except NoGameInChatError:
+        await send_async(context.bot, chat.id,
+                   text=_("No game is running at the moment. "
+                          "Create a new game with /new"),
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=thread_id)
+        return
 
-        except AlreadyJoinedError:
-            game = gm.chatid_games.get(chat.id, [None])[-1]
-            await send_async(context.bot, chat.id,
-                       text=_("You already joined the game. Start the game "
-                              "with /start"),
-                       reply_to_message_id=update.message.message_id,
-                       message_thread_id=game.thread_id if game else thread_id)
-            return
+    except AlreadyJoinedError:
+        game = _game_in_chat(chat.id, thread_id)
+        await send_async(context.bot, chat.id,
+                   text=_("You already joined the game. Start the game "
+                          "with /start"),
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id if game else thread_id)
+        return
 
-        except DeckEmptyError:
-            game = gm.chatid_games.get(chat.id, [None])[-1]
-            await send_async(context.bot, chat.id,
-                       text=_("There are not enough cards left in the deck for "
-                              "new players to join."),
-                       reply_to_message_id=update.message.message_id,
-                       message_thread_id=game.thread_id if game else thread_id)
-            return
+    except DeckEmptyError:
+        game = _game_in_chat(chat.id, thread_id)
+        await send_async(context.bot, chat.id,
+                   text=_("There are not enough cards left in the deck for "
+                          "new players to join."),
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id if game else thread_id)
+        return
 
     # Success — get the game the player just joined
     player = gm.player_for_user_in_chat(update.message.from_user, chat)
@@ -226,23 +248,21 @@ async def leave_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     game = player.game
 
-    chat_lock = gm.get_chat_lock(chat.id)
-    async with chat_lock:
-        try:
-            gm.leave_game(user, chat)
+    try:
+        gm.leave_game(user, chat)
 
-        except NoGameInChatError:
-            await send_async(context.bot, chat.id, text=_("You are not playing in a game in "
-                                            "this group."),
-                       reply_to_message_id=update.message.message_id,
-                       message_thread_id=game.thread_id)
-            return
+    except NoGameInChatError:
+        await send_async(context.bot, chat.id, text=_("You are not playing in a game in "
+                                        "this group."),
+                   reply_to_message_id=update.message.message_id,
+                   message_thread_id=game.thread_id)
+        return
 
-        except NotEnoughPlayersError:
-            gm.end_game(chat, user)
-            await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate),
-                       message_thread_id=game.thread_id)
-            return
+    except NotEnoughPlayersError:
+        gm.end_game(chat, user)
+        await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate),
+                   message_thread_id=game.thread_id)
+        return
 
     if game.started:
         await send_async(context.bot, chat.id,
@@ -270,17 +290,16 @@ async def kick_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     chat = update.message.chat
     user = update.message.from_user
+    thread_id = get_thread_id(update)
+    game = _game_in_chat(chat.id, thread_id)
 
-    try:
-        game = gm.chatid_games[chat.id][-1]
-
-    except (KeyError, IndexError):
-            await send_async(context.bot, chat.id,
-                   text=_("No game is running at the moment. "
-                          "Create a new game with /new"),
-                   reply_to_message_id=update.message.message_id,
-                   message_thread_id=get_thread_id(update))
-            return
+    if game is None:
+        await send_async(context.bot, chat.id,
+               text=_("No game is running at the moment. "
+                      "Create a new game with /new"),
+               reply_to_message_id=update.message.message_id,
+               message_thread_id=thread_id)
+        return
 
     if not game.started:
         await send_async(context.bot, chat.id,
@@ -295,25 +314,23 @@ async def kick_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if update.message.reply_to_message:
             kicked = update.message.reply_to_message.from_user
 
-            chat_lock = gm.get_chat_lock(chat.id)
-            async with chat_lock:
-                try:
-                    gm.leave_game(kicked, chat)
+            try:
+                gm.leave_game(kicked, chat)
 
-                except NoGameInChatError:
-                    await send_async(context.bot, chat.id, text=_("Player {name} is not found in the current game.".format(name=display_name(kicked))),
-                                    reply_to_message_id=update.message.message_id,
-                                    message_thread_id=game.thread_id)
-                    return
+            except NoGameInChatError:
+                await send_async(context.bot, chat.id, text=_("Player {name} is not found in the current game.".format(name=display_name(kicked))),
+                                reply_to_message_id=update.message.message_id,
+                                message_thread_id=game.thread_id)
+                return
 
-                except NotEnoughPlayersError:
-                    gm.end_game(chat, user)
-                    await send_async(context.bot, chat.id,
-                                    text=_("{0} was kicked by {1}".format(display_name(kicked), display_name(user))),
-                                    message_thread_id=game.thread_id)
-                    await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate),
-                                    message_thread_id=game.thread_id)
-                    return
+            except NotEnoughPlayersError:
+                gm.end_game(chat, user)
+                await send_async(context.bot, chat.id,
+                                text=_("{0} was kicked by {1}".format(display_name(kicked), display_name(user))),
+                                message_thread_id=game.thread_id)
+                await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate),
+                                message_thread_id=game.thread_id)
+                return
 
             await send_async(context.bot, chat.id,
                             text=_("{0} was kicked by {1}".format(display_name(kicked), display_name(user))),
@@ -386,24 +403,22 @@ async def status_update(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if update.message.left_chat_member:
         user = update.message.left_chat_member
 
-        chat_lock = gm.get_chat_lock(chat.id)
-        async with chat_lock:
-            player = gm.player_for_user_in_chat(user, chat)
-            if not player:
-                return
+        player = gm.player_for_user_in_chat(user, chat)
+        if not player:
+            return
 
-            game = player.game
+        game = player.game
 
-            try:
-                gm.leave_game(user, chat)
-            except NoGameInChatError:
-                return
-            except NotEnoughPlayersError:
-                gm.end_game(chat, user)
-                await send_async(context.bot, chat.id, text=__("Game ended!",
-                                                 multi=game.translate),
-                           message_thread_id=game.thread_id)
-                return
+        try:
+            gm.leave_game(user, chat)
+        except NoGameInChatError:
+            return
+        except NotEnoughPlayersError:
+            gm.end_game(chat, user)
+            await send_async(context.bot, chat.id, text=__("Game ended!",
+                                             multi=game.translate),
+                       message_thread_id=game.thread_id)
+            return
 
         await send_async(context.bot, chat.id, text=__("Removing {name} from the game",
                                          multi=game.translate)
@@ -419,10 +434,9 @@ async def start_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if update.message.chat.type != 'private':
         chat = update.message.chat
         thread_id = get_thread_id(update)
+        game = _game_in_chat(chat.id, thread_id)
 
-        try:
-            game = gm.chatid_games[chat.id][-1]
-        except (KeyError, IndexError):
+        if game is None:
             await send_async(context.bot, chat.id,
                        text=_("There is no game running in this chat. Create "
                               "a new one with /new"),
@@ -441,12 +455,10 @@ async def start_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         else:
             # Starting a game
-            chat_lock = gm.get_chat_lock(chat.id)
-            async with chat_lock:
-                game.start()
+            game.start()
 
-                for player in game.players:
-                    player.draw_first_hand()
+            for player in game.players:
+                player.draw_first_hand()
 
             choice = [[InlineKeyboardButton(text=_("Make your choice!"), switch_inline_query_current_chat='')]]
             first_message = (
@@ -497,15 +509,14 @@ async def close_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /close command"""
     chat = update.message.chat
     user = update.message.from_user
-    games = gm.chatid_games.get(chat.id)
+    thread_id = get_thread_id(update)
+    game = _game_in_chat(chat.id, thread_id)
 
-    if not games:
+    if game is None:
         await send_async(context.bot, chat.id,
                    text=_("There is no running game in this chat."),
-                   message_thread_id=get_thread_id(update))
+                   message_thread_id=thread_id)
         return
-
-    game = games[-1]
 
     if user.id in game.owner:
         game.open = False
@@ -528,15 +539,14 @@ async def open_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /open command"""
     chat = update.message.chat
     user = update.message.from_user
-    games = gm.chatid_games.get(chat.id)
+    thread_id = get_thread_id(update)
+    game = _game_in_chat(chat.id, thread_id)
 
-    if not games:
+    if game is None:
         await send_async(context.bot, chat.id,
                    text=_("There is no running game in this chat."),
-                   message_thread_id=get_thread_id(update))
+                   message_thread_id=thread_id)
         return
-
-    game = games[-1]
 
     if user.id in game.owner:
         game.open = True
@@ -558,15 +568,14 @@ async def enable_translations(update: Update, context: ContextTypes.DEFAULT_TYPE
     """Handler for the /enable_translations command"""
     chat = update.message.chat
     user = update.message.from_user
-    games = gm.chatid_games.get(chat.id)
+    thread_id = get_thread_id(update)
+    game = _game_in_chat(chat.id, thread_id)
 
-    if not games:
+    if game is None:
         await send_async(context.bot, chat.id,
                    text=_("There is no running game in this chat."),
-                   message_thread_id=get_thread_id(update))
+                   message_thread_id=thread_id)
         return
-
-    game = games[-1]
 
     if user.id in game.owner:
         game.translate = True
@@ -589,15 +598,14 @@ async def disable_translations(update: Update, context: ContextTypes.DEFAULT_TYP
     """Handler for the /disable_translations command"""
     chat = update.message.chat
     user = update.message.from_user
-    games = gm.chatid_games.get(chat.id)
+    thread_id = get_thread_id(update)
+    game = _game_in_chat(chat.id, thread_id)
 
-    if not games:
+    if game is None:
         await send_async(context.bot, chat.id,
                    text=_("There is no running game in this chat."),
-                   message_thread_id=get_thread_id(update))
+                   message_thread_id=thread_id)
         return
-
-    game = games[-1]
 
     if user.id in game.owner:
         game.translate = False
@@ -649,8 +657,7 @@ async def skip_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
                    reply_to_message_id=update.message.message_id,
                    message_thread_id=game.thread_id)
     else:
-        async with game.lock:
-            await do_skip(context.bot, player)
+        await do_skip(context.bot, player)
 
 
 @game_locales
@@ -663,15 +670,21 @@ async def reply_to_query(update: Update, context: ContextTypes.DEFAULT_TYPE):
     results = list()
     switch = None
 
+    has_game = False
     try:
         user = update.inline_query.from_user
         user_id = user.id
         players = gm.userid_players[user_id]
         player = gm.userid_current[user_id]
         game = player.game
+        has_game = True
     except KeyError:
+        players = []
+        player = None
+        game = None
         add_no_game(results)
-    else:
+
+    if has_game:
 
         # The game has not started.
         # The creator may change the game mode, other users just get a "game has not started" message.
@@ -722,14 +735,19 @@ async def reply_to_query(update: Update, context: ContextTypes.DEFAULT_TYPE):
         else:
             add_gameinfo(game, results)
 
-        # v22: Telegram objects are frozen, use _unfrozen() to modify IDs
-        anti_cheat_suffix = ':%d' % player.anti_cheat
-        for result in results:
-            with result._unfrozen():
-                result.id += anti_cheat_suffix
-
         if players and game and len(players) > 1:
             switch = _('Current game: {game}').format(game=game.chat.title)
+
+    # Re-encode every result_id as <game_id>:<base_id>:<anti_cheat> so the
+    # UpdateProcessor can route ChosenInlineResult updates to the right game
+    # lock and process_result can resolve the game directly. Non-game results
+    # (no_game sentinel) are tagged with the pseudo game-id 'none' so the
+    # decode contract stays uniform.
+    if has_game:
+        encode_results_list(results, game_id=game.id,
+                            anti_cheat=player.anti_cheat)
+    else:
+        encode_results_list(results, game_id=PSEUDO_GAME_ID, anti_cheat=0)
 
     button = None
     if switch:
@@ -744,58 +762,85 @@ async def process_result(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """
     Handler for chosen inline results.
     Checks the players actions and acts accordingly.
+
+    Per-game serialization is owned by :class:`UnoUpdateProcessor`; this
+    handler runs inside the (chat, thread) lock and must not acquire its own.
     """
     try:
         user = update.chosen_inline_result.from_user
-        player = gm.userid_current[user.id]
-        game = player.game
-        result_id = update.chosen_inline_result.result_id
-        chat = game.chat
-    except (KeyError, AttributeError):
+        raw_result_id = update.chosen_inline_result.result_id
+    except AttributeError:
         return
 
-    logger.debug("Selected result: " + result_id)
+    logger.debug("Selected result: " + raw_result_id)
 
-    result_id, anti_cheat = result_id.split(':')
-
-    if result_id in ('hand', 'gameinfo', 'nogame'):
+    decoded = decode_result_id(raw_result_id)
+    if decoded is None:
+        # Old-format ID (bot was restarted mid-game) or unknown sentinel.
         return
-    elif result_id.startswith('mode_'):
-        # First 5 characters are 'mode_', the rest is the gamemode.
-        mode = result_id[5:]
+
+    base_id = decoded.base_id
+    anti_cheat = decoded.anti_cheat
+
+    if base_id in ('hand', 'gameinfo', 'nogame'):
+        return
+
+    resolved = resolve_result(gm, decoded, user_id=user.id)
+    if resolved.dead_reason is not None:
+        # AC-8: the game has ended (or the user was kicked) between
+        # answer_inline_query and chosen_inline_result. Telegram does not give
+        # us the chat the user was typing in, so the only feedback channel is
+        # a direct message — send_async swallows "bot can't initiate chat"
+        # errors for users who never started a DM with the bot.
+        if resolved.dead_reason == DEAD_UNKNOWN_GAME:
+            hint = _("This game has already ended.")
+        elif resolved.dead_reason == DEAD_NOT_A_PLAYER:
+            hint = _("You are no longer in this game.")
+        else:  # DEAD_NO_CURRENT_GAME
+            hint = _("You are not in a game right now. "
+                     "Use /new to start one or /join to join an existing game.")
+        await send_async(context.bot, user.id, text=hint)
+        return
+
+    game = resolved.game
+    player = resolved.player
+    chat = game.chat
+
+    if base_id.startswith('mode_'):
+        mode = base_id[5:]
         if mode not in ('classic', 'fast', 'wild', 'text'):
             return
         game.set_mode(mode)
-        logger.info("Gamemode changed to {mode}".format(mode = mode))
-        await send_async(context.bot, chat.id, text=__("Gamemode changed to {mode}".format(mode = mode)),
-                   message_thread_id=game.thread_id)
+        logger.info("Gamemode changed to {mode}".format(mode=mode))
+        await send_async(context.bot, chat.id,
+                         text=__("Gamemode changed to {mode}".format(mode=mode)),
+                         message_thread_id=game.thread_id)
         return
-    elif len(result_id) == 36:  # UUID result
+    if len(base_id) == 36:  # UUID-only result (legacy "other cards" placeholder)
         return
 
-    async with game.lock:
-        if int(anti_cheat) != player.anti_cheat:
-            await send_async(context.bot, chat.id,
-                       text=__("Cheat attempt by {name}", multi=game.translate)
-                       .format(name=display_name(player.user)),
-                       message_thread_id=game.thread_id)
-            return
+    if anti_cheat != player.anti_cheat:
+        await send_async(context.bot, chat.id,
+                         text=__("Cheat attempt by {name}", multi=game.translate)
+                         .format(name=display_name(player.user)),
+                         message_thread_id=game.thread_id)
+        return
 
-        player.anti_cheat += 1
+    player.anti_cheat += 1
 
-        if result_id == 'call_bluff':
-            reset_waiting_time(context.bot, player)
-            await do_call_bluff(context.bot, player)
-        elif result_id == 'draw':
-            reset_waiting_time(context.bot, player)
-            await do_draw(context.bot, player)
-        elif result_id == 'pass':
-            game.turn()
-        elif result_id in c.COLORS:
-            game.choose_color(result_id)
-        else:
-            reset_waiting_time(context.bot, player)
-            await do_play_card(context.bot, player, result_id)
+    if base_id == 'call_bluff':
+        reset_waiting_time(context.bot, player)
+        await do_call_bluff(context.bot, player)
+    elif base_id == 'draw':
+        reset_waiting_time(context.bot, player)
+        await do_draw(context.bot, player)
+    elif base_id == 'pass':
+        game.turn()
+    elif base_id in c.COLORS:
+        game.choose_color(base_id)
+    else:
+        reset_waiting_time(context.bot, player)
+        await do_play_card(context.bot, player, base_id)
 
     if game_is_running(game):
         nextplayer_message = (

--- a/bot.py
+++ b/bot.py
@@ -44,7 +44,7 @@ from shared_vars import gm, application
 from simple_commands import help_handler
 from start_bot import start_bot
 from utils import display_name
-from utils import send_async, answer_async, error, TIMEOUT, user_is_creator_or_admin, user_is_creator, game_is_running
+from utils import send_async, answer_async, error, user_is_creator_or_admin, user_is_creator, game_is_running
 
 
 logging.basicConfig(
@@ -470,13 +470,11 @@ async def start_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
             await context.bot.send_sticker(chat.id,
                             sticker=c.STICKERS[str(game.last_card)],
-                            read_timeout=TIMEOUT, write_timeout=TIMEOUT,
                             message_thread_id=game.thread_id)
 
             await context.bot.send_message(chat.id,
                             text=first_message,
                             reply_markup=InlineKeyboardMarkup(choice),
-                            read_timeout=TIMEOUT, write_timeout=TIMEOUT,
                             message_thread_id=game.thread_id)
 
             start_player_countdown(context.bot, game, context.job_queue)
@@ -829,17 +827,17 @@ async def process_result(update: Update, context: ContextTypes.DEFAULT_TYPE):
     player.anti_cheat += 1
 
     if base_id == 'call_bluff':
-        reset_waiting_time(context.bot, player)
+        await reset_waiting_time(context.bot, player)
         await do_call_bluff(context.bot, player)
     elif base_id == 'draw':
-        reset_waiting_time(context.bot, player)
+        await reset_waiting_time(context.bot, player)
         await do_draw(context.bot, player)
     elif base_id == 'pass':
         game.turn()
     elif base_id in c.COLORS:
         game.choose_color(base_id)
     else:
-        reset_waiting_time(context.bot, player)
+        await reset_waiting_time(context.bot, player)
         await do_play_card(context.bot, player, base_id)
 
     if game_is_running(game):
@@ -854,10 +852,18 @@ async def process_result(update: Update, context: ContextTypes.DEFAULT_TYPE):
         start_player_countdown(context.bot, game, context.job_queue)
 
 
-def reset_waiting_time(bot, player):
-    """Resets waiting time for a player"""
+async def reset_waiting_time(bot, player):
+    """Resets waiting time for a player and notifies the chat."""
     if player.waiting_time < WAITING_TIME:
         player.waiting_time = WAITING_TIME
+        game = player.game
+        await send_async(bot, game.chat.id,
+                         text=__("Waiting time for {name} has been reset to "
+                                 "{time} seconds",
+                                 multi=game.translate)
+                         .format(name=display_name(player.user),
+                                 time=WAITING_TIME),
+                         message_thread_id=game.thread_id)
 
 
 # Add all handlers to the application and run the bot

--- a/bot.py
+++ b/bot.py
@@ -20,11 +20,11 @@
 import logging
 from datetime import datetime
 
-from telegram import ParseMode, InlineKeyboardMarkup, \
+from telegram import InlineKeyboardMarkup, \
     InlineKeyboardButton, Update
+from telegram.constants import ParseMode
 from telegram.ext import InlineQueryHandler, ChosenInlineResultHandler, \
-    CommandHandler, MessageHandler, Filters, CallbackQueryHandler, CallbackContext
-from telegram.ext.dispatcher import run_async
+    CommandHandler, MessageHandler, filters, CallbackQueryHandler, ContextTypes
 
 import card as c
 import settings
@@ -37,7 +37,7 @@ from internationalization import _, __, user_locale, game_locales
 from results import (add_call_bluff, add_choose_color, add_draw, add_gameinfo,
                      add_no_game, add_not_started, add_other_cards, add_pass,
                      add_card, add_mode_classic, add_mode_fast, add_mode_wild, add_mode_text)
-from shared_vars import gm, updater, dispatcher
+from shared_vars import gm, application
 from simple_commands import help_handler
 from start_bot import start_bot
 from utils import display_name
@@ -52,11 +52,11 @@ logger = logging.getLogger(__name__)
 logging.getLogger('apscheduler').setLevel(logging.WARNING)
 
 @user_locale
-def notify_me(update: Update, context: CallbackContext):
+async def notify_me(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for /notify_me command, pm people for next game"""
     chat_id = update.message.chat_id
     if update.message.chat.type == 'private':
-        send_async(bot,
+        await send_async(context.bot,
                    chat_id,
                    text=_("Send this command in a group to be notified "
                           "when a new game is started there."))
@@ -68,110 +68,118 @@ def notify_me(update: Update, context: CallbackContext):
 
 
 @user_locale
-def new_game(update: Update, context: CallbackContext):
+async def new_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /new command"""
     chat_id = update.message.chat_id
 
     if update.message.chat.type == 'private':
-        help_handler(update, context)
+        await help_handler(update, context)
 
     else:
+        chat_lock = gm.get_chat_lock(chat_id)
+        async with chat_lock:
+            if update.message.chat_id in gm.remind_dict:
+                for user in gm.remind_dict[update.message.chat_id]:
+                    await send_async(context.bot,
+                               user,
+                               text=_("A new game has been started in {title}").format(
+                                    title=update.message.chat.title))
 
-        if update.message.chat_id in gm.remind_dict:
-            for user in gm.remind_dict[update.message.chat_id]:
-                send_async(context.bot,
-                           user,
-                           text=_("A new game has been started in {title}").format(
-                                title=update.message.chat.title))
+                del gm.remind_dict[update.message.chat_id]
 
-            del gm.remind_dict[update.message.chat_id]
+            game = gm.new_game(update.message.chat)
+            game.starter = update.message.from_user
+            game.owner.append(update.message.from_user.id)
+            game.mode = DEFAULT_GAMEMODE
 
-        game = gm.new_game(update.message.chat)
-        game.starter = update.message.from_user
-        game.owner.append(update.message.from_user.id)
-        game.mode = DEFAULT_GAMEMODE
-        send_async(context.bot, chat_id,
+        await send_async(context.bot, chat_id,
                    text=_("Created a new game! Join the game with /join "
                           "and start the game with /start"))
 
 
 @user_locale
-def kill_game(update: Update, context: CallbackContext):
+async def kill_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /kill command"""
     chat = update.message.chat
     user = update.message.from_user
     games = gm.chatid_games.get(chat.id)
 
     if update.message.chat.type == 'private':
-        help_handler(update, context)
+        await help_handler(update, context)
         return
 
     if not games:
-            send_async(context.bot, chat.id,
+            await send_async(context.bot, chat.id,
                        text=_("There is no running game in this chat."))
             return
 
     game = games[-1]
 
-    if user_is_creator_or_admin(user, game, context.bot, chat):
+    if await user_is_creator_or_admin(user, game, context.bot, chat):
+        chat_lock = gm.get_chat_lock(chat.id)
+        async with chat_lock:
+            try:
+                await gm.end_game(chat, user)
+                await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
 
-        try:
-            gm.end_game(chat, user)
-            send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
-
-        except NoGameInChatError:
-            send_async(context.bot, chat.id,
-                       text=_("The game is not started yet. "
-                              "Join the game with /join and start the game with /start"),
-                       reply_to_message_id=update.message.message_id)
+            except NoGameInChatError:
+                await send_async(context.bot, chat.id,
+                           text=_("The game is not started yet. "
+                                  "Join the game with /join and start the game with /start"),
+                           reply_to_message_id=update.message.message_id)
 
     else:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                   text=_("Only the game creator ({name}) and admin can do that.")
                   .format(name=game.starter.first_name),
                   reply_to_message_id=update.message.message_id)
 
 @user_locale
-def join_game(update: Update, context: CallbackContext):
+async def join_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /join command"""
     chat = update.message.chat
 
     if update.message.chat.type == 'private':
-        help_handler(update, context)
+        await help_handler(update, context)
         return
 
-    try:
-        gm.join_game(update.message.from_user, chat)
+    chat_lock = gm.get_chat_lock(chat.id)
+    async with chat_lock:
+        try:
+            gm.join_game(update.message.from_user, chat)
 
-    except LobbyClosedError:
-            send_async(context.bot, chat.id, text=_("The lobby is closed"))
+        except LobbyClosedError:
+                await send_async(context.bot, chat.id, text=_("The lobby is closed"))
+                return
 
-    except NoGameInChatError:
-        send_async(context.bot, chat.id,
-                   text=_("No game is running at the moment. "
-                          "Create a new game with /new"),
-                   reply_to_message_id=update.message.message_id)
+        except NoGameInChatError:
+            await send_async(context.bot, chat.id,
+                       text=_("No game is running at the moment. "
+                              "Create a new game with /new"),
+                       reply_to_message_id=update.message.message_id)
+            return
 
-    except AlreadyJoinedError:
-        send_async(context.bot, chat.id,
-                   text=_("You already joined the game. Start the game "
-                          "with /start"),
-                   reply_to_message_id=update.message.message_id)
+        except AlreadyJoinedError:
+            await send_async(context.bot, chat.id,
+                       text=_("You already joined the game. Start the game "
+                              "with /start"),
+                       reply_to_message_id=update.message.message_id)
+            return
 
-    except DeckEmptyError:
-        send_async(context.bot, chat.id,
-                   text=_("There are not enough cards left in the deck for "
-                          "new players to join."),
-                   reply_to_message_id=update.message.message_id)
+        except DeckEmptyError:
+            await send_async(context.bot, chat.id,
+                       text=_("There are not enough cards left in the deck for "
+                              "new players to join."),
+                       reply_to_message_id=update.message.message_id)
+            return
 
-    else:
-        send_async(context.bot, chat.id,
-                   text=_("Joined the game"),
-                   reply_to_message_id=update.message.message_id)
+    await send_async(context.bot, chat.id,
+               text=_("Joined the game"),
+               reply_to_message_id=update.message.message_id)
 
 
 @user_locale
-def leave_game(update: Update, context: CallbackContext):
+async def leave_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /leave command"""
     chat = update.message.chat
     user = update.message.from_user
@@ -179,47 +187,49 @@ def leave_game(update: Update, context: CallbackContext):
     player = gm.player_for_user_in_chat(user, chat)
 
     if player is None:
-        send_async(context.bot, chat.id, text=_("You are not playing in a game in "
+        await send_async(context.bot, chat.id, text=_("You are not playing in a game in "
                                         "this group."),
                    reply_to_message_id=update.message.message_id)
         return
 
     game = player.game
-    user = update.message.from_user
 
-    try:
-        gm.leave_game(user, chat)
+    chat_lock = gm.get_chat_lock(chat.id)
+    async with chat_lock:
+        try:
+            gm.leave_game(user, chat)
 
-    except NoGameInChatError:
-        send_async(context.bot, chat.id, text=_("You are not playing in a game in "
-                                        "this group."),
+        except NoGameInChatError:
+            await send_async(context.bot, chat.id, text=_("You are not playing in a game in "
+                                            "this group."),
+                       reply_to_message_id=update.message.message_id)
+            return
+
+        except NotEnoughPlayersError:
+            await gm.end_game(chat, user)
+            await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
+            return
+
+    if game.started:
+        await send_async(context.bot, chat.id,
+                   text=__("Okay. Next Player: {name}",
+                           multi=game.translate).format(
+                       name=display_name(game.current_player.user)),
                    reply_to_message_id=update.message.message_id)
-
-    except NotEnoughPlayersError:
-        gm.end_game(chat, user)
-        send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
-
     else:
-        if game.started:
-            send_async(context.bot, chat.id,
-                       text=__("Okay. Next Player: {name}",
-                               multi=game.translate).format(
-                           name=display_name(game.current_player.user)),
-                       reply_to_message_id=update.message.message_id)
-        else:
-            send_async(context.bot, chat.id,
-                       text=__("{name} left the game before it started.",
-                               multi=game.translate).format(
-                           name=display_name(user)),
-                       reply_to_message_id=update.message.message_id)
+        await send_async(context.bot, chat.id,
+                   text=__("{name} left the game before it started.",
+                           multi=game.translate).format(
+                       name=display_name(user)),
+                   reply_to_message_id=update.message.message_id)
 
 
 @user_locale
-def kick_player(update: Update, context: CallbackContext):
+async def kick_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /kick command"""
 
     if update.message.chat.type == 'private':
-        help_handler(update, context)
+        await help_handler(update, context)
         return
 
     chat = update.message.chat
@@ -229,62 +239,64 @@ def kick_player(update: Update, context: CallbackContext):
         game = gm.chatid_games[chat.id][-1]
 
     except (KeyError, IndexError):
-            send_async(context.bot, chat.id,
+            await send_async(context.bot, chat.id,
                    text=_("No game is running at the moment. "
                           "Create a new game with /new"),
                    reply_to_message_id=update.message.message_id)
             return
 
     if not game.started:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("The game is not started yet. "
                           "Join the game with /join and start the game with /start"),
                    reply_to_message_id=update.message.message_id)
         return
 
-    if user_is_creator_or_admin(user, game, context.bot, chat):
+    if await user_is_creator_or_admin(user, game, context.bot, chat):
 
         if update.message.reply_to_message:
             kicked = update.message.reply_to_message.from_user
 
-            try:
-                gm.leave_game(kicked, chat)
+            chat_lock = gm.get_chat_lock(chat.id)
+            async with chat_lock:
+                try:
+                    gm.leave_game(kicked, chat)
 
-            except NoGameInChatError:
-                send_async(context.bot, chat.id, text=_("Player {name} is not found in the current game.".format(name=display_name(kicked))),
-                                reply_to_message_id=update.message.message_id)
-                return
+                except NoGameInChatError:
+                    await send_async(context.bot, chat.id, text=_("Player {name} is not found in the current game.".format(name=display_name(kicked))),
+                                    reply_to_message_id=update.message.message_id)
+                    return
 
-            except NotEnoughPlayersError:
-                gm.end_game(chat, user)
-                send_async(context.bot, chat.id,
-                                text=_("{0} was kicked by {1}".format(display_name(kicked), display_name(user))))
-                send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
-                return
+                except NotEnoughPlayersError:
+                    await gm.end_game(chat, user)
+                    await send_async(context.bot, chat.id,
+                                    text=_("{0} was kicked by {1}".format(display_name(kicked), display_name(user))))
+                    await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
+                    return
 
-            send_async(context.bot, chat.id,
+            await send_async(context.bot, chat.id,
                             text=_("{0} was kicked by {1}".format(display_name(kicked), display_name(user))))
 
         else:
-            send_async(context.bot, chat.id,
+            await send_async(context.bot, chat.id,
                 text=_("Please reply to the person you want to kick and type /kick again."),
                 reply_to_message_id=update.message.message_id)
             return
 
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=__("Okay. Next Player: {name}",
                            multi=game.translate).format(
                        name=display_name(game.current_player.user)),
                    reply_to_message_id=update.message.message_id)
 
     else:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                   text=_("Only the game creator ({name}) and admin can do that.")
                   .format(name=game.starter.first_name),
                   reply_to_message_id=update.message.message_id)
 
 
-def select_game(update: Update, context: CallbackContext):
+async def select_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for callback queries to select the current game"""
 
     chat_id = int(update.callback_query.data)
@@ -295,59 +307,59 @@ def select_game(update: Update, context: CallbackContext):
             gm.userid_current[user_id] = player
             break
     else:
-        send_async(bot,
+        await send_async(context.bot,
                    update.callback_query.message.chat_id,
                    text=_("Game not found."))
         return
 
-    def selected():
-        back = [[InlineKeyboardButton(text=_("Back to last group"),
-                                      switch_inline_query='')]]
-        context.bot.answerCallbackQuery(update.callback_query.id,
-                                text=_("Please switch to the group you selected!"),
-                                show_alert=False,
-                                timeout=TIMEOUT)
+    back = [[InlineKeyboardButton(text=_("Back to last group"),
+                                  switch_inline_query='')]]
+    await context.bot.answer_callback_query(
+        update.callback_query.id,
+        text=_("Please switch to the group you selected!"),
+        show_alert=False)
 
-        context.bot.editMessageText(chat_id=update.callback_query.message.chat_id,
-                            message_id=update.callback_query.message.message_id,
-                            text=_("Selected group: {group}\n"
-                                   "<b>Make sure that you switch to the correct "
-                                   "group!</b>").format(
-                                group=gm.userid_current[user_id].game.chat.title),
-                            reply_markup=InlineKeyboardMarkup(back),
-                            parse_mode=ParseMode.HTML,
-                            timeout=TIMEOUT)
-
-    dispatcher.run_async(selected)
+    await context.bot.edit_message_text(
+        chat_id=update.callback_query.message.chat_id,
+        message_id=update.callback_query.message.message_id,
+        text=_("Selected group: {group}\n"
+               "<b>Make sure that you switch to the correct "
+               "group!</b>").format(
+            group=gm.userid_current[user_id].game.chat.title),
+        reply_markup=InlineKeyboardMarkup(back),
+        parse_mode=ParseMode.HTML)
 
 
 @game_locales
-def status_update(update: Update, context: CallbackContext):
+async def status_update(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Remove player from game if user leaves the group"""
     chat = update.message.chat
 
     if update.message.left_chat_member:
         user = update.message.left_chat_member
 
-        try:
-            gm.leave_game(user, chat)
-            game = gm.player_for_user_in_chat(user, chat).game
+        chat_lock = gm.get_chat_lock(chat.id)
+        async with chat_lock:
+            try:
+                gm.leave_game(user, chat)
+                game = gm.player_for_user_in_chat(user, chat).game
 
-        except NoGameInChatError:
-            pass
-        except NotEnoughPlayersError:
-            gm.end_game(chat, user)
-            send_async(context.bot, chat.id, text=__("Game ended!",
-                                             multi=game.translate))
-        else:
-            send_async(context.bot, chat.id, text=__("Removing {name} from the game",
-                                             multi=game.translate)
-                       .format(name=display_name(user)))
+            except NoGameInChatError:
+                return
+            except NotEnoughPlayersError:
+                await gm.end_game(chat, user)
+                await send_async(context.bot, chat.id, text=__("Game ended!",
+                                                 multi=game.translate))
+                return
+
+        await send_async(context.bot, chat.id, text=__("Removing {name} from the game",
+                                         multi=game.translate)
+                   .format(name=display_name(user)))
 
 
 @game_locales
 @user_locale
-def start_game(update: Update, context: CallbackContext):
+async def start_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /start command"""
 
     if update.message.chat.type != 'private':
@@ -356,25 +368,28 @@ def start_game(update: Update, context: CallbackContext):
         try:
             game = gm.chatid_games[chat.id][-1]
         except (KeyError, IndexError):
-            send_async(context.bot, chat.id,
+            await send_async(context.bot, chat.id,
                        text=_("There is no game running in this chat. Create "
                               "a new one with /new"))
             return
 
         if game.started:
-            send_async(context.bot, chat.id, text=_("The game has already started"))
+            await send_async(context.bot, chat.id, text=_("The game has already started"))
 
         elif len(game.players) < MIN_PLAYERS:
-            send_async(context.bot, chat.id,
+            await send_async(context.bot, chat.id,
                        text=__("At least {minplayers} players must /join the game "
                               "before you can start it").format(minplayers=MIN_PLAYERS))
 
         else:
             # Starting a game
-            game.start()
+            chat_lock = gm.get_chat_lock(chat.id)
+            async with chat_lock:
+                game.start()
 
-            for player in game.players:
-                player.draw_first_hand()
+                for player in game.players:
+                    player.draw_first_hand()
+
             choice = [[InlineKeyboardButton(text=_("Make your choice!"), switch_inline_query_current_chat='')]]
             first_message = (
                 __("First player: {name}\n"
@@ -383,22 +398,18 @@ def start_game(update: Update, context: CallbackContext):
                    multi=game.translate)
                 .format(name=display_name(game.current_player.user)))
 
-            def send_first():
-                """Send the first card and player"""
+            await context.bot.send_sticker(chat.id,
+                            sticker=c.STICKERS[str(game.last_card)],
+                            read_timeout=TIMEOUT)
 
-                context.bot.sendSticker(chat.id,
-                                sticker=c.STICKERS[str(game.last_card)],
-                                timeout=TIMEOUT)
+            await context.bot.send_message(chat.id,
+                            text=first_message,
+                            reply_markup=InlineKeyboardMarkup(choice),
+                            read_timeout=TIMEOUT)
 
-                context.bot.sendMessage(chat.id,
-                                text=first_message,
-                                reply_markup=InlineKeyboardMarkup(choice),
-                                timeout=TIMEOUT)
-
-            dispatcher.run_async(send_first)
             start_player_countdown(context.bot, game, context.job_queue)
 
-    elif len(context.args) and context.args[0] == 'select':
+    elif context.args and context.args[0] == 'select':
         players = gm.userid_players[update.message.from_user.id]
 
         groups = list()
@@ -413,23 +424,23 @@ def start_game(update: Update, context: CallbackContext):
                                       callback_data=str(player.game.chat.id))]
             )
 
-        send_async(context.bot, update.message.chat_id,
+        await send_async(context.bot, update.message.chat_id,
                    text=_('Please select the group you want to play in.'),
                    reply_markup=InlineKeyboardMarkup(groups))
 
     else:
-        help_handler(update, context)
+        await help_handler(update, context)
 
 
 @user_locale
-def close_game(update: Update, context: CallbackContext):
+async def close_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /close command"""
     chat = update.message.chat
     user = update.message.from_user
     games = gm.chatid_games.get(chat.id)
 
     if not games:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("There is no running game in this chat."))
         return
 
@@ -437,12 +448,12 @@ def close_game(update: Update, context: CallbackContext):
 
     if user.id in game.owner:
         game.open = False
-        send_async(context.bot, chat.id, text=_("Closed the lobby. "
+        await send_async(context.bot, chat.id, text=_("Closed the lobby. "
                                         "No more players can join this game."))
         return
 
     else:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("Only the game creator ({name}) and admin can do that.")
                    .format(name=game.starter.first_name),
                    reply_to_message_id=update.message.message_id)
@@ -450,14 +461,14 @@ def close_game(update: Update, context: CallbackContext):
 
 
 @user_locale
-def open_game(update: Update, context: CallbackContext):
+async def open_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /open command"""
     chat = update.message.chat
     user = update.message.from_user
     games = gm.chatid_games.get(chat.id)
 
     if not games:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("There is no running game in this chat."))
         return
 
@@ -465,11 +476,11 @@ def open_game(update: Update, context: CallbackContext):
 
     if user.id in game.owner:
         game.open = True
-        send_async(context.bot, chat.id, text=_("Opened the lobby. "
+        await send_async(context.bot, chat.id, text=_("Opened the lobby. "
                                         "New players may /join the game."))
         return
     else:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("Only the game creator ({name}) and admin can do that.")
                    .format(name=game.starter.first_name),
                    reply_to_message_id=update.message.message_id)
@@ -477,14 +488,14 @@ def open_game(update: Update, context: CallbackContext):
 
 
 @user_locale
-def enable_translations(update: Update, context: CallbackContext):
+async def enable_translations(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /enable_translations command"""
     chat = update.message.chat
     user = update.message.from_user
     games = gm.chatid_games.get(chat.id)
 
     if not games:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("There is no running game in this chat."))
         return
 
@@ -492,12 +503,12 @@ def enable_translations(update: Update, context: CallbackContext):
 
     if user.id in game.owner:
         game.translate = True
-        send_async(context.bot, chat.id, text=_("Enabled multi-translations. "
+        await send_async(context.bot, chat.id, text=_("Enabled multi-translations. "
                                         "Disable with /disable_translations"))
         return
 
     else:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("Only the game creator ({name}) and admin can do that.")
                    .format(name=game.starter.first_name),
                    reply_to_message_id=update.message.message_id)
@@ -505,14 +516,14 @@ def enable_translations(update: Update, context: CallbackContext):
 
 
 @user_locale
-def disable_translations(update: Update, context: CallbackContext):
+async def disable_translations(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /disable_translations command"""
     chat = update.message.chat
     user = update.message.from_user
     games = gm.chatid_games.get(chat.id)
 
     if not games:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("There is no running game in this chat."))
         return
 
@@ -520,13 +531,13 @@ def disable_translations(update: Update, context: CallbackContext):
 
     if user.id in game.owner:
         game.translate = False
-        send_async(context.bot, chat.id, text=_("Disabled multi-translations. "
+        await send_async(context.bot, chat.id, text=_("Disabled multi-translations. "
                                         "Enable them again with "
                                         "/enable_translations"))
         return
 
     else:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("Only the game creator ({name}) and admin can do that.")
                    .format(name=game.starter.first_name),
                    reply_to_message_id=update.message.message_id)
@@ -535,14 +546,14 @@ def disable_translations(update: Update, context: CallbackContext):
 
 @game_locales
 @user_locale
-def skip_player(update: Update, context: CallbackContext):
+async def skip_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /skip command"""
     chat = update.message.chat
     user = update.message.from_user
 
     player = gm.player_for_user_in_chat(user, chat)
     if not player:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("You are not playing in a game in this chat."))
         return
 
@@ -557,19 +568,20 @@ def skip_player(update: Update, context: CallbackContext):
     # You can skip yourself even if you have time left (you'll still draw)
     if delta < skipped_player.waiting_time and player != skipped_player:
         n = skipped_player.waiting_time - delta
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("Please wait {time} second",
                           "Please wait {time} seconds",
                           n)
                    .format(time=n),
                    reply_to_message_id=update.message.message_id)
     else:
-        do_skip(context.bot, player)
+        async with game.lock:
+            await do_skip(context.bot, player)
 
 
 @game_locales
 @user_locale
-def reply_to_query(update: Update, context: CallbackContext):
+async def reply_to_query(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """
     Handler for inline queries.
     Builds the result list for inline queries and answers to the client.
@@ -637,13 +649,13 @@ def reply_to_query(update: Update, context: CallbackContext):
         if players and game and len(players) > 1:
             switch = _('Current game: {game}').format(game=game.chat.title)
 
-    answer_async(context.bot, update.inline_query.id, results, cache_time=0,
+    await answer_async(context.bot, update.inline_query.id, results, cache_time=0,
                  switch_pm_text=switch, switch_pm_parameter='select')
 
 
 @game_locales
 @user_locale
-def process_result(update: Update, context: CallbackContext):
+async def process_result(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """
     Handler for chosen inline results.
     Checks the players actions and acts accordingly.
@@ -661,7 +673,6 @@ def process_result(update: Update, context: CallbackContext):
 
     result_id, anti_cheat = result_id.split(':')
     last_anti_cheat = player.anti_cheat
-    player.anti_cheat += 1
 
     if result_id in ('hand', 'gameinfo', 'nogame'):
         return
@@ -670,35 +681,39 @@ def process_result(update: Update, context: CallbackContext):
         mode = result_id[5:]
         game.set_mode(mode)
         logger.info("Gamemode changed to {mode}".format(mode = mode))
-        send_async(context.bot, chat.id, text=__("Gamemode changed to {mode}".format(mode = mode)))
+        await send_async(context.bot, chat.id, text=__("Gamemode changed to {mode}".format(mode = mode)))
         return
     elif len(result_id) == 36:  # UUID result
         return
     elif int(anti_cheat) != last_anti_cheat:
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=__("Cheat attempt by {name}", multi=game.translate)
                    .format(name=display_name(player.user)))
         return
-    elif result_id == 'call_bluff':
-        reset_waiting_time(context.bot, player)
-        do_call_bluff(context.bot, player)
-    elif result_id == 'draw':
-        reset_waiting_time(context.bot, player)
-        do_draw(context.bot, player)
-    elif result_id == 'pass':
-        game.turn()
-    elif result_id in c.COLORS:
-        game.choose_color(result_id)
-    else:
-        reset_waiting_time(context.bot, player)
-        do_play_card(context.bot, player, result_id)
+
+    async with game.lock:
+        player.anti_cheat += 1
+
+        if result_id == 'call_bluff':
+            reset_waiting_time(context.bot, player)
+            await do_call_bluff(context.bot, player)
+        elif result_id == 'draw':
+            reset_waiting_time(context.bot, player)
+            await do_draw(context.bot, player)
+        elif result_id == 'pass':
+            game.turn()
+        elif result_id in c.COLORS:
+            game.choose_color(result_id)
+        else:
+            reset_waiting_time(context.bot, player)
+            await do_play_card(context.bot, player, result_id)
 
     if game_is_running(game):
         nextplayer_message = (
             __("Next player: {name}", multi=game.translate)
             .format(name=display_name(game.current_player.user)))
         choice = [[InlineKeyboardButton(text=_("Make your choice!"), switch_inline_query_current_chat='')]]
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                         text=nextplayer_message,
                         reply_markup=InlineKeyboardMarkup(choice))
         start_player_countdown(context.bot, game, context.job_queue)
@@ -710,34 +725,29 @@ def reset_waiting_time(bot, player):
 
     if player.waiting_time < WAITING_TIME:
         player.waiting_time = WAITING_TIME
-        send_async(bot, chat.id,
-                   text=__("Waiting time for {name} has been reset to {time} "
-                           "seconds", multi=player.game.translate)
-                   .format(name=display_name(player.user), time=WAITING_TIME))
 
 
-# Add all handlers to the dispatcher and run the bot
-dispatcher.add_handler(InlineQueryHandler(reply_to_query))
-dispatcher.add_handler(ChosenInlineResultHandler(process_result, pass_job_queue=True))
-dispatcher.add_handler(CallbackQueryHandler(select_game))
-dispatcher.add_handler(CommandHandler('start', start_game, pass_args=True, pass_job_queue=True))
-dispatcher.add_handler(CommandHandler('new', new_game))
-dispatcher.add_handler(CommandHandler('kill', kill_game))
-dispatcher.add_handler(CommandHandler('join', join_game))
-dispatcher.add_handler(CommandHandler('leave', leave_game))
-dispatcher.add_handler(CommandHandler('kick', kick_player))
-dispatcher.add_handler(CommandHandler('open', open_game))
-dispatcher.add_handler(CommandHandler('close', close_game))
-dispatcher.add_handler(CommandHandler('enable_translations',
+# Add all handlers to the application and run the bot
+application.add_handler(InlineQueryHandler(reply_to_query))
+application.add_handler(ChosenInlineResultHandler(process_result))
+application.add_handler(CallbackQueryHandler(select_game))
+application.add_handler(CommandHandler('start', start_game))
+application.add_handler(CommandHandler('new', new_game))
+application.add_handler(CommandHandler('kill', kill_game))
+application.add_handler(CommandHandler('join', join_game))
+application.add_handler(CommandHandler('leave', leave_game))
+application.add_handler(CommandHandler('kick', kick_player))
+application.add_handler(CommandHandler('open', open_game))
+application.add_handler(CommandHandler('close', close_game))
+application.add_handler(CommandHandler('enable_translations',
                                       enable_translations))
-dispatcher.add_handler(CommandHandler('disable_translations',
+application.add_handler(CommandHandler('disable_translations',
                                       disable_translations))
-dispatcher.add_handler(CommandHandler('skip', skip_player))
-dispatcher.add_handler(CommandHandler('notify_me', notify_me))
+application.add_handler(CommandHandler('skip', skip_player))
+application.add_handler(CommandHandler('notify_me', notify_me))
 simple_commands.register()
 settings.register()
-dispatcher.add_handler(MessageHandler(Filters.status_update, status_update))
-dispatcher.add_error_handler(error)
+application.add_handler(MessageHandler(filters.StatusUpdate.LEFT_CHAT_MEMBER, status_update))
+application.add_error_handler(error)
 
-start_bot(updater)
-updater.idle()
+start_bot(application)

--- a/bot.py
+++ b/bot.py
@@ -119,7 +119,7 @@ async def kill_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
         chat_lock = gm.get_chat_lock(chat.id)
         async with chat_lock:
             try:
-                await gm.end_game(chat, user)
+                gm.end_game(chat, user)
                 await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
 
             except NoGameInChatError:
@@ -206,7 +206,7 @@ async def leave_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return
 
         except NotEnoughPlayersError:
-            await gm.end_game(chat, user)
+            gm.end_game(chat, user)
             await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
             return
 
@@ -268,7 +268,7 @@ async def kick_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     return
 
                 except NotEnoughPlayersError:
-                    await gm.end_game(chat, user)
+                    gm.end_game(chat, user)
                     await send_async(context.bot, chat.id,
                                     text=_("{0} was kicked by {1}".format(display_name(kicked), display_name(user))))
                     await send_async(context.bot, chat.id, text=__("Game ended!", multi=game.translate))
@@ -340,14 +340,18 @@ async def status_update(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         chat_lock = gm.get_chat_lock(chat.id)
         async with chat_lock:
+            player = gm.player_for_user_in_chat(user, chat)
+            if not player:
+                return
+
+            game = player.game
+
             try:
                 gm.leave_game(user, chat)
-                game = gm.player_for_user_in_chat(user, chat).game
-
             except NoGameInChatError:
                 return
             except NotEnoughPlayersError:
-                await gm.end_game(chat, user)
+                gm.end_game(chat, user)
                 await send_async(context.bot, chat.id, text=__("Game ended!",
                                                  multi=game.translate))
                 return
@@ -400,12 +404,12 @@ async def start_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
             await context.bot.send_sticker(chat.id,
                             sticker=c.STICKERS[str(game.last_card)],
-                            read_timeout=TIMEOUT)
+                            read_timeout=TIMEOUT, write_timeout=TIMEOUT)
 
             await context.bot.send_message(chat.id,
                             text=first_message,
                             reply_markup=InlineKeyboardMarkup(choice),
-                            read_timeout=TIMEOUT)
+                            read_timeout=TIMEOUT, write_timeout=TIMEOUT)
 
             start_player_countdown(context.bot, game, context.job_queue)
 
@@ -672,7 +676,6 @@ async def process_result(update: Update, context: ContextTypes.DEFAULT_TYPE):
     logger.debug("Selected result: " + result_id)
 
     result_id, anti_cheat = result_id.split(':')
-    last_anti_cheat = player.anti_cheat
 
     if result_id in ('hand', 'gameinfo', 'nogame'):
         return
@@ -685,13 +688,14 @@ async def process_result(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
     elif len(result_id) == 36:  # UUID result
         return
-    elif int(anti_cheat) != last_anti_cheat:
-        await send_async(context.bot, chat.id,
-                   text=__("Cheat attempt by {name}", multi=game.translate)
-                   .format(name=display_name(player.user)))
-        return
 
     async with game.lock:
+        if int(anti_cheat) != player.anti_cheat:
+            await send_async(context.bot, chat.id,
+                       text=__("Cheat attempt by {name}", multi=game.translate)
+                       .format(name=display_name(player.user)))
+            return
+
         player.anti_cheat += 1
 
         if result_id == 'call_bluff':

--- a/bot.py
+++ b/bot.py
@@ -20,8 +20,8 @@
 import logging
 from datetime import datetime
 
-from telegram import InlineKeyboardMarkup, \
-    InlineKeyboardButton, Update
+from telegram import BotCommand, InlineKeyboardMarkup, \
+    InlineKeyboardButton, InlineQueryResultsButton, Update
 from telegram.constants import ParseMode
 from telegram.ext import InlineQueryHandler, ChosenInlineResultHandler, \
     CommandHandler, MessageHandler, filters, CallbackQueryHandler, ContextTypes
@@ -707,14 +707,20 @@ async def reply_to_query(update: Update, context: ContextTypes.DEFAULT_TYPE):
         else:
             add_gameinfo(game, results)
 
+        # v22: Telegram objects are frozen, use _unfrozen() to modify IDs
+        anti_cheat_suffix = ':%d' % player.anti_cheat
         for result in results:
-            result.id += ':%d' % player.anti_cheat
+            with result._unfrozen():
+                result.id += anti_cheat_suffix
 
         if players and game and len(players) > 1:
             switch = _('Current game: {game}').format(game=game.chat.title)
 
+    button = None
+    if switch:
+        button = InlineQueryResultsButton(text=switch, start_parameter='select')
     await answer_async(context.bot, update.inline_query.id, results, cache_time=0,
-                 switch_pm_text=switch, switch_pm_parameter='select')
+                 button=button)
 
 
 @game_locales
@@ -818,5 +824,29 @@ simple_commands.register()
 settings.register()
 application.add_handler(MessageHandler(filters.StatusUpdate.LEFT_CHAT_MEMBER, status_update))
 application.add_error_handler(error)
+
+
+async def post_init(application):
+    """Set bot commands on startup so Telegram clients show them"""
+    await application.bot.set_my_commands([
+        BotCommand('new', 'Start a new game'),
+        BotCommand('join', 'Join the current game'),
+        BotCommand('start', 'Start the game'),
+        BotCommand('leave', 'Leave the game you\'re in'),
+        BotCommand('close', 'Close the game lobby'),
+        BotCommand('open', 'Open the game lobby'),
+        BotCommand('kill', 'Terminate the game'),
+        BotCommand('kick', 'Kick players out of the game'),
+        BotCommand('skip', 'Skip the current player'),
+        BotCommand('notify_me', 'Get notified about new games'),
+        BotCommand('help', 'How to use this bot?'),
+        BotCommand('modes', 'Explanation of game modes'),
+        BotCommand('settings', 'Language and other settings'),
+        BotCommand('stats', 'Show statistics'),
+        BotCommand('source', 'See source information'),
+        BotCommand('news', 'All news about this bot'),
+    ])
+
+application.post_init = post_init
 
 start_bot(application)

--- a/bot.py
+++ b/bot.py
@@ -63,15 +63,12 @@ def get_thread_id(update):
 
 
 def _game_in_chat(chat_id, thread_id):
-    """Resolve the active game in this (chat, thread). Falls back to any game
-    in the same chat when thread_id is None — this preserves previous UX where
-    /kill from the General channel could close a topic-bound game."""
-    game = gm.game_for_chat_topic(chat_id, thread_id)
-    if game is not None:
-        return game
-    if thread_id is None:
-        return gm._any_game_in_chat(chat_id)
-    return None
+    """Resolve the active game in this ``(chat, thread)`` or ``None``.
+
+    No cross-topic fallback — a user typing in General can only act on the
+    General-channel game, never on a topic-bound game.
+    """
+    return gm.game_for_chat_topic(chat_id, thread_id)
 
 
 def _resolve_game_id(game_id):
@@ -222,8 +219,9 @@ async def join_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
                    message_thread_id=game.thread_id if game else thread_id)
         return
 
-    # Success — get the game the player just joined
-    player = gm.player_for_user_in_chat(update.message.from_user, chat)
+    # Success — confirm in the topic of the game the player just joined
+    player = gm.player_for_user_in_chat(update.message.from_user, chat,
+                                         thread_id=thread_id)
     game_thread = player.game.thread_id if player else thread_id
     await send_async(context.bot, chat.id,
                text=_("Joined the game"),
@@ -236,20 +234,21 @@ async def leave_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /leave command"""
     chat = update.message.chat
     user = update.message.from_user
+    thread_id = get_thread_id(update)
 
-    player = gm.player_for_user_in_chat(user, chat)
+    player = gm.player_for_user_in_chat(user, chat, thread_id=thread_id)
 
     if player is None:
         await send_async(context.bot, chat.id, text=_("You are not playing in a game in "
                                         "this group."),
                    reply_to_message_id=update.message.message_id,
-                   message_thread_id=get_thread_id(update))
+                   message_thread_id=thread_id)
         return
 
     game = player.game
 
     try:
-        gm.leave_game(user, chat)
+        gm.leave_game(user, chat, thread_id=thread_id)
 
     except NoGameInChatError:
         await send_async(context.bot, chat.id, text=_("You are not playing in a game in "
@@ -315,7 +314,7 @@ async def kick_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
             kicked = update.message.reply_to_message.from_user
 
             try:
-                gm.leave_game(kicked, chat)
+                gm.leave_game(kicked, chat, thread_id=thread_id)
 
             except NoGameInChatError:
                 await send_async(context.bot, chat.id, text=_("Player {name} is not found in the current game.".format(name=display_name(kicked))),
@@ -397,33 +396,44 @@ async def select_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 @game_locales
 async def status_update(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Remove player from game if user leaves the group"""
+    """Remove player from every game in the chat when they leave the group.
+
+    The user may have been in several topic-bound games at once — Telegram
+    only tells us they left the group as a whole, not which topic they were
+    playing in, so we clean them out of every active game in the chat and
+    announce in each affected topic.
+    """
     chat = update.message.chat
 
     if update.message.left_chat_member:
         user = update.message.left_chat_member
 
-        player = gm.player_for_user_in_chat(user, chat)
-        if not player:
+        # Snapshot all games the user is in, before they get removed
+        affected = []
+        for game in list(gm._games_in_chat(chat.id)):
+            if any(p.user.id == user.id for p in game.players):
+                affected.append(game)
+
+        if not affected:
             return
 
-        game = player.game
+        for game in affected:
+            try:
+                gm.leave_game(user, chat, thread_id=game.thread_id)
+            except NoGameInChatError:
+                continue
+            except NotEnoughPlayersError:
+                gm.end_game(chat, user)
+                await send_async(context.bot, chat.id,
+                                 text=__("Game ended!", multi=game.translate),
+                                 message_thread_id=game.thread_id)
+                continue
 
-        try:
-            gm.leave_game(user, chat)
-        except NoGameInChatError:
-            return
-        except NotEnoughPlayersError:
-            gm.end_game(chat, user)
-            await send_async(context.bot, chat.id, text=__("Game ended!",
-                                             multi=game.translate),
-                       message_thread_id=game.thread_id)
-            return
-
-        await send_async(context.bot, chat.id, text=__("Removing {name} from the game",
-                                         multi=game.translate)
-                   .format(name=display_name(user)),
-                   message_thread_id=game.thread_id)
+            await send_async(context.bot, chat.id,
+                             text=__("Removing {name} from the game",
+                                     multi=game.translate)
+                             .format(name=display_name(user)),
+                             message_thread_id=game.thread_id)
 
 
 @game_locales
@@ -628,12 +638,13 @@ async def skip_player(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /skip command"""
     chat = update.message.chat
     user = update.message.from_user
+    thread_id = get_thread_id(update)
 
-    player = gm.player_for_user_in_chat(user, chat)
+    player = gm.player_for_user_in_chat(user, chat, thread_id=thread_id)
     if not player:
         await send_async(context.bot, chat.id,
                    text=_("You are not playing in a game in this chat."),
-                   message_thread_id=get_thread_id(update))
+                   message_thread_id=thread_id)
         return
 
     game = player.game

--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@
 
 import os
 import json
+import sys
 
 try:
     with open("config.json", "r") as f:
@@ -28,11 +29,17 @@ except FileNotFoundError:
     config = {}
 
 TOKEN = os.getenv("TOKEN", config.get("token"))
+if not TOKEN:
+    sys.exit("ERROR: Bot token is not configured. Set 'token' in config.json or TOKEN environment variable.")
+
 WORKERS = int(os.getenv("WORKERS", config.get("workers", 32)))
 ADMIN_LIST = os.getenv("ADMIN_LIST", config.get("admin_list", None))
 
 if isinstance(ADMIN_LIST, str):
-    ADMIN_LIST = set(int(x) for x in ADMIN_LIST.split())
+    try:
+        ADMIN_LIST = set(int(x) for x in ADMIN_LIST.split())
+    except ValueError:
+        sys.exit("ERROR: ADMIN_LIST contains non-numeric values. Expected space-separated user IDs.")
 
 OPEN_LOBBY = os.getenv("OPEN_LOBBY", config.get("open_lobby", True))
 ENABLE_TRANSLATIONS = os.getenv("ENABLE_TRANSLATIONS", config.get("enable_translations", False))

--- a/errors.py
+++ b/errors.py
@@ -36,3 +36,8 @@ class NotEnoughPlayersError(Exception):
 
 class DeckEmptyError(Exception):
     pass
+
+
+class GameAlreadyRunningError(Exception):
+    """Raised when /new is invoked in a (chat, topic) that already hosts a game."""
+    pass

--- a/game.py
+++ b/game.py
@@ -45,6 +45,7 @@ class Game(object):
         self.chat = chat
         self.last_card = None
         self.lock = asyncio.Lock()
+        self.thread_id = None
 
         self.deck = Deck()
 

--- a/game.py
+++ b/game.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
+import asyncio
 import logging
 from config import ADMIN_LIST, OPEN_LOBBY, DEFAULT_GAMEMODE, ENABLE_TRANSLATIONS
 from datetime import datetime
@@ -43,6 +44,7 @@ class Game(object):
     def __init__(self, chat):
         self.chat = chat
         self.last_card = None
+        self.lock = asyncio.Lock()
 
         self.deck = Deck()
 

--- a/game.py
+++ b/game.py
@@ -18,8 +18,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-import asyncio
 import logging
+import uuid
 from config import ADMIN_LIST, OPEN_LOBBY, DEFAULT_GAMEMODE, ENABLE_TRANSLATIONS
 from datetime import datetime
 
@@ -42,8 +42,8 @@ class Game(object):
 
     def __init__(self, chat):
         self.chat = chat
+        self.id = uuid.uuid4().hex[:12]
         self.last_card = None
-        self.lock = asyncio.Lock()
         self.thread_id = None
         self.owner = list(ADMIN_LIST) if ADMIN_LIST else []
 

--- a/game.py
+++ b/game.py
@@ -37,7 +37,6 @@ class Game(object):
     starter = None
     mode = DEFAULT_GAMEMODE
     job = None
-    owner = ADMIN_LIST
     open = OPEN_LOBBY
     translate = ENABLE_TRANSLATIONS
 
@@ -46,6 +45,7 @@ class Game(object):
         self.last_card = None
         self.lock = asyncio.Lock()
         self.thread_id = None
+        self.owner = list(ADMIN_LIST) if ADMIN_LIST else []
 
         self.deck = Deck()
 

--- a/game_manager.py
+++ b/game_manager.py
@@ -23,54 +23,64 @@ import logging
 
 from game import Game
 from player import Player
-from errors import (AlreadyJoinedError, LobbyClosedError, NoGameInChatError,
-                    NotEnoughPlayersError)
+from errors import (AlreadyJoinedError, GameAlreadyRunningError,
+                    LobbyClosedError, NoGameInChatError, NotEnoughPlayersError)
 from promotions import send_promotion
 
+
 class GameManager(object):
-    """ Manages all running games by using a confusing amount of dicts """
+    """Owns all running games — keyed by ``(chat_id, thread_id)``.
+
+    Each ``(chat_id, thread_id)`` may host **at most one** active game.
+    Concurrency is handled by :class:`uno_update_processor.UnoUpdateProcessor`,
+    not in this manager. ``update_processor`` is set from ``shared_vars`` after
+    construction so that ``end_game`` can release the matching lock.
+    """
 
     def __init__(self):
-        self.chatid_games = dict()
+        self.chatid_games = dict()        # (chat_id, thread_id) -> Game
+        self.games_by_id = dict()         # game.id -> Game
         self.userid_players = dict()
         self.userid_current = dict()
         self.remind_dict = dict()
-        self.chat_locks = dict()
+        self.update_processor = None      # set by shared_vars after wiring
 
         self.logger = logging.getLogger(__name__)
 
-    def get_chat_lock(self, chat_id):
-        """Returns the asyncio.Lock for a given chat, creating one if needed"""
-        return self.chat_locks.setdefault(chat_id, asyncio.Lock())
-
-    def new_game(self, chat):
-        """
-        Create a new game in this chat
-        """
+    def new_game(self, chat, thread_id=None):
+        """Create a new game in this chat/topic. Singleton per (chat, topic)."""
         chat_id = chat.id
+        key = (chat_id, thread_id)
 
-        self.logger.debug("Creating new game in chat " + str(chat_id))
+        existing = self.chatid_games.get(key)
+        if existing is not None and existing.players:
+            raise GameAlreadyRunningError()
+
+        if existing is not None:
+            # An empty stale lobby — drop it before replacing.
+            self._forget_game(existing)
+
+        self.logger.debug("Creating new game in chat %s topic %s",
+                          chat_id, thread_id)
         game = Game(chat)
+        game.thread_id = thread_id
 
-        if chat_id not in self.chatid_games:
-            self.chatid_games[chat_id] = list()
-
-        # remove old games
-        for g in list(self.chatid_games[chat_id]):
-            if not g.players:
-                self.chatid_games[chat_id].remove(g)
-
-        self.chatid_games[chat_id].append(game)
+        self.chatid_games[key] = game
+        self.games_by_id[game.id] = game
         return game
 
-    def join_game(self, user, chat):
-        """ Create a player from the Telegram user and add it to the game """
-        self.logger.info("Joining game with id " + str(chat.id))
+    def join_game(self, user, chat, thread_id=None):
+        """Create a player from the Telegram user and add it to the game."""
+        self.logger.info("Joining game with chat id " + str(chat.id))
 
-        try:
-            game = self.chatid_games[chat.id][-1]
-        except (KeyError, IndexError):
-            raise NoGameInChatError()
+        game = self.game_for_chat_topic(chat.id, thread_id)
+        if game is None:
+            # Backwards-friendly: if no exact (chat, topic) game exists but the
+            # caller did not specify a thread, fall back to any game in the chat.
+            if thread_id is None:
+                game = self._any_game_in_chat(chat.id)
+            if game is None:
+                raise NoGameInChatError()
 
         if not game.open:
             raise LobbyClosedError()
@@ -80,7 +90,7 @@ class GameManager(object):
 
         players = self.userid_players[user.id]
 
-        # Don not re-add a player and remove the player from previous games in
+        # Don't re-add a player and remove the player from previous games in
         # this chat, if he is in one of them
         for player in players:
             if player in game.players:
@@ -106,19 +116,17 @@ class GameManager(object):
         self.userid_current[user.id] = player
 
     def leave_game(self, user, chat):
-        """ Remove a player from its current game """
+        """Remove a player from its current game."""
 
         player = self.player_for_user_in_chat(user, chat)
         players = self.userid_players.get(user.id, list())
 
         if not player:
-            games = self.chatid_games[chat.id]
-            for g in games:
-                for p in g.players:
+            for game in self._games_in_chat(chat.id):
+                for p in game.players:
                     if p.user.id == user.id:
-                        if p == g.current_player:
-                            g.turn()
-
+                        if p == game.current_player:
+                            game.turn()
                         p.leave()
                         return
 
@@ -144,15 +152,11 @@ class GameManager(object):
                 del self.userid_players[user.id]
 
     def end_game(self, chat, user):
-        """
-        End a game
-        """
+        """End a game."""
 
         self.logger.info("Game in chat " + str(chat.id) + " ended")
 
-        # Find the correct game instance to end
         player = self.player_for_user_in_chat(user, chat)
-
         if not player:
             raise NoGameInChatError
 
@@ -164,7 +168,7 @@ class GameManager(object):
         except RuntimeError:
             pass
 
-        # Clear game
+        # Clear all players from the userid maps
         for player_in_game in game.players:
             this_users_players = \
                 self.userid_players.get(player_in_game.user.id, list())
@@ -175,24 +179,20 @@ class GameManager(object):
                 pass
 
             if this_users_players:
-                try:
-                    self.userid_current[player_in_game.user.id] = this_users_players[0]
-                except KeyError:
-                    pass
+                self.userid_current[player_in_game.user.id] = this_users_players[0]
             else:
-                try:
-                    del self.userid_players[player_in_game.user.id]
-                except KeyError:
-                    pass
+                self.userid_players.pop(player_in_game.user.id, None)
+                self.userid_current.pop(player_in_game.user.id, None)
 
-                try:
-                    del self.userid_current[player_in_game.user.id]
-                except KeyError:
-                    pass
+        self._forget_game(game)
 
-        self.chatid_games[chat.id].remove(game)
-        if not self.chatid_games[chat.id]:
-            del self.chatid_games[chat.id]
+    def game_for_chat_topic(self, chat_id, thread_id):
+        """Return the active Game for ``(chat_id, thread_id)`` or ``None``."""
+        return self.chatid_games.get((chat_id, thread_id))
+
+    def game_by_id(self, game_id):
+        """Return the active Game with the given ``game.id`` or ``None``."""
+        return self.games_by_id.get(game_id)
 
     def player_for_user_in_chat(self, user, chat):
         players = self.userid_players.get(user.id, list())
@@ -200,3 +200,29 @@ class GameManager(object):
             if player.game.chat.id == chat.id:
                 return player
         return None
+
+    # -- internal helpers -------------------------------------------------
+
+    def _games_in_chat(self, chat_id):
+        """Yield every active game whose chat matches ``chat_id``."""
+        for (cid, _tid), game in self.chatid_games.items():
+            if cid == chat_id:
+                yield game
+
+    def _any_game_in_chat(self, chat_id):
+        for game in self._games_in_chat(chat_id):
+            return game
+        return None
+
+    def _forget_game(self, game):
+        """Drop a game from all in-memory indexes and release its lock."""
+        key = (game.chat.id, game.thread_id)
+        self.chatid_games.pop(key, None)
+        self.games_by_id.pop(game.id, None)
+
+        processor = self.update_processor
+        if processor is not None:
+            try:
+                processor.release_key(key)
+            except Exception:  # pragma: no cover - defensive
+                self.logger.exception("Failed to release processor lock for %s", key)

--- a/game_manager.py
+++ b/game_manager.py
@@ -18,13 +18,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
+import asyncio
 import logging
 
 from game import Game
 from player import Player
 from errors import (AlreadyJoinedError, LobbyClosedError, NoGameInChatError,
                     NotEnoughPlayersError)
-from promotions import send_promotion_async
+from promotions import send_promotion
 
 class GameManager(object):
     """ Manages all running games by using a confusing amount of dicts """
@@ -34,8 +35,15 @@ class GameManager(object):
         self.userid_players = dict()
         self.userid_current = dict()
         self.remind_dict = dict()
+        self.chat_locks = dict()
 
         self.logger = logging.getLogger(__name__)
+
+    def get_chat_lock(self, chat_id):
+        """Returns the asyncio.Lock for a given chat, creating one if needed"""
+        if chat_id not in self.chat_locks:
+            self.chat_locks[chat_id] = asyncio.Lock()
+        return self.chat_locks[chat_id]
 
     def new_game(self, chat):
         """
@@ -137,13 +145,13 @@ class GameManager(object):
                 del self.userid_current[user.id]
                 del self.userid_players[user.id]
 
-    def end_game(self, chat, user):
+    async def end_game(self, chat, user):
         """
         End a game
         """
 
         self.logger.info("Game in chat " + str(chat.id) + " ended")
-        send_promotion_async(chat, chance=0.15)
+        await send_promotion(chat, chance=0.15)
 
         # Find the correct game instance to end
         player = self.player_for_user_in_chat(user, chat)

--- a/game_manager.py
+++ b/game_manager.py
@@ -41,9 +41,7 @@ class GameManager(object):
 
     def get_chat_lock(self, chat_id):
         """Returns the asyncio.Lock for a given chat, creating one if needed"""
-        if chat_id not in self.chat_locks:
-            self.chat_locks[chat_id] = asyncio.Lock()
-        return self.chat_locks[chat_id]
+        return self.chat_locks.setdefault(chat_id, asyncio.Lock())
 
     def new_game(self, chat):
         """
@@ -152,7 +150,7 @@ class GameManager(object):
 
         self.logger.info("Game in chat " + str(chat.id) + " ended")
         try:
-            asyncio.get_event_loop().create_task(send_promotion(chat, chance=0.15))
+            asyncio.get_running_loop().create_task(send_promotion(chat, chance=0.15))
         except RuntimeError:
             pass
 

--- a/game_manager.py
+++ b/game_manager.py
@@ -145,13 +145,16 @@ class GameManager(object):
                 del self.userid_current[user.id]
                 del self.userid_players[user.id]
 
-    async def end_game(self, chat, user):
+    def end_game(self, chat, user):
         """
         End a game
         """
 
         self.logger.info("Game in chat " + str(chat.id) + " ended")
-        await send_promotion(chat, chance=0.15)
+        try:
+            asyncio.get_event_loop().create_task(send_promotion(chat, chance=0.15))
+        except RuntimeError:
+            pass
 
         # Find the correct game instance to end
         player = self.player_for_user_in_chat(user, chat)

--- a/game_manager.py
+++ b/game_manager.py
@@ -149,10 +149,6 @@ class GameManager(object):
         """
 
         self.logger.info("Game in chat " + str(chat.id) + " ended")
-        try:
-            asyncio.get_running_loop().create_task(send_promotion(chat, chance=0.15))
-        except RuntimeError:
-            pass
 
         # Find the correct game instance to end
         player = self.player_for_user_in_chat(user, chat)
@@ -161,6 +157,12 @@ class GameManager(object):
             raise NoGameInChatError
 
         game = player.game
+
+        try:
+            asyncio.get_running_loop().create_task(
+                send_promotion(chat, chance=0.15, message_thread_id=game.thread_id))
+        except RuntimeError:
+            pass
 
         # Clear game
         for player_in_game in game.players:

--- a/game_manager.py
+++ b/game_manager.py
@@ -48,6 +48,9 @@ class GameManager(object):
         self.userid_current = dict()
         self.remind_dict = dict()
         self.update_processor = None      # set by shared_vars after wiring
+        # Strong references for fire-and-forget background tasks
+        # (asyncio docs: tasks may be GC'd mid-flight without a strong ref).
+        self._background_tasks = set()
 
         self.logger = logging.getLogger(__name__)
 
@@ -190,8 +193,12 @@ class GameManager(object):
         game = player.game
 
         try:
-            asyncio.get_running_loop().create_task(
+            task = asyncio.get_running_loop().create_task(
                 send_promotion(chat, chance=0.15, message_thread_id=game.thread_id))
+            # Strong reference + self-removal on completion, per the asyncio
+            # docs (`create_task` Important box).
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
         except RuntimeError:
             pass
 

--- a/game_manager.py
+++ b/game_manager.py
@@ -35,6 +35,10 @@ class GameManager(object):
     Concurrency is handled by :class:`uno_update_processor.UnoUpdateProcessor`,
     not in this manager. ``update_processor`` is set from ``shared_vars`` after
     construction so that ``end_game`` can release the matching lock.
+
+    All public lookup/mutation methods that touch a single game take an
+    explicit ``thread_id``. There is no cross-topic fallback — a caller in
+    the General channel cannot accidentally act on a topic-bound game.
     """
 
     def __init__(self):
@@ -70,17 +74,12 @@ class GameManager(object):
         return game
 
     def join_game(self, user, chat, thread_id=None):
-        """Create a player from the Telegram user and add it to the game."""
-        self.logger.info("Joining game with chat id " + str(chat.id))
+        """Add a player to the game in this ``(chat, thread_id)``."""
+        self.logger.info("Joining game in chat %s topic %s", chat.id, thread_id)
 
         game = self.game_for_chat_topic(chat.id, thread_id)
         if game is None:
-            # Backwards-friendly: if no exact (chat, topic) game exists but the
-            # caller did not specify a thread, fall back to any game in the chat.
-            if thread_id is None:
-                game = self._any_game_in_chat(chat.id)
-            if game is None:
-                raise NoGameInChatError()
+            raise NoGameInChatError()
 
         if not game.open:
             raise LobbyClosedError()
@@ -90,14 +89,15 @@ class GameManager(object):
 
         players = self.userid_players[user.id]
 
-        # Don't re-add a player and remove the player from previous games in
-        # this chat, if he is in one of them
+        # Reject re-joining the same game
         for player in players:
             if player in game.players:
                 raise AlreadyJoinedError()
 
+        # If the user is already in *this* (chat, thread_id) game (via a
+        # different player slot), drop the old slot first
         try:
-            self.leave_game(user, chat)
+            self.leave_game(user, chat, thread_id=thread_id)
         except NoGameInChatError:
             pass
         except NotEnoughPlayersError:
@@ -115,22 +115,17 @@ class GameManager(object):
         players.append(player)
         self.userid_current[user.id] = player
 
-    def leave_game(self, user, chat):
-        """Remove a player from its current game."""
+    def leave_game(self, user, chat, thread_id=None):
+        """Remove a player from the game in this ``(chat, thread_id)``.
 
-        player = self.player_for_user_in_chat(user, chat)
-        players = self.userid_players.get(user.id, list())
-
-        if not player:
-            for game in self._games_in_chat(chat.id):
-                for p in game.players:
-                    if p.user.id == user.id:
-                        if p == game.current_player:
-                            game.turn()
-                        p.leave()
-                        return
-
-            raise NoGameInChatError
+        Raises :class:`NoGameInChatError` if the user is not playing in that
+        specific topic. To remove a user from every game in a chat (e.g. when
+        Telegram fires ``left_chat_member``), use
+        :meth:`leave_all_games_in_chat` instead.
+        """
+        player = self.player_for_user_in_chat(user, chat, thread_id=thread_id)
+        if player is None:
+            raise NoGameInChatError()
 
         game = player.game
 
@@ -141,23 +136,55 @@ class GameManager(object):
             game.turn()
 
         player.leave()
-        players.remove(player)
 
-        # If this is the selected game, switch to another
+        players = self.userid_players.get(user.id, list())
+        try:
+            players.remove(player)
+        except ValueError:
+            pass
+
+        # Re-point userid_current if we just removed the active selection
         if self.userid_current.get(user.id, None) is player:
             if players:
                 self.userid_current[user.id] = players[0]
             else:
-                del self.userid_current[user.id]
-                del self.userid_players[user.id]
+                self.userid_current.pop(user.id, None)
+                self.userid_players.pop(user.id, None)
+
+    def leave_all_games_in_chat(self, user, chat):
+        """Remove ``user`` from every active game in ``chat``.
+
+        Used when Telegram tells us the user left the group entirely — at
+        that point we don't know which topic they were playing in, so we
+        clean them out of all of them. Never raises.
+        """
+        for game in list(self._games_in_chat(chat.id)):
+            try:
+                self.leave_game(user, chat, thread_id=game.thread_id)
+            except NoGameInChatError:
+                continue
+            except NotEnoughPlayersError:
+                # Caller (status_update) handles the announcement after the
+                # game ends; propagate by ending the game ourselves.
+                self.end_game(chat, user)
 
     def end_game(self, chat, user):
-        """End a game."""
+        """End the game whose ``current_player`` includes ``user``."""
 
-        self.logger.info("Game in chat " + str(chat.id) + " ended")
+        self.logger.info("Game in chat %s ended", chat.id)
 
-        player = self.player_for_user_in_chat(user, chat)
-        if not player:
+        # End the first game in the chat where this user is a player. Since
+        # a user can be in at most one game per (chat, thread), this is
+        # unambiguous within a topic.
+        player = None
+        for game in self._games_in_chat(chat.id):
+            for p in game.players:
+                if p.user.id == user.id:
+                    player = p
+                    break
+            if player is not None:
+                break
+        if player is None:
             raise NoGameInChatError
 
         game = player.game
@@ -194,10 +221,17 @@ class GameManager(object):
         """Return the active Game with the given ``game.id`` or ``None``."""
         return self.games_by_id.get(game_id)
 
-    def player_for_user_in_chat(self, user, chat):
-        players = self.userid_players.get(user.id, list())
-        for player in players:
-            if player.game.chat.id == chat.id:
+    def player_for_user_in_chat(self, user, chat, thread_id=None):
+        """Return the ``Player`` for ``user`` in the ``(chat, thread_id)`` game.
+
+        Returns ``None`` if the user is not in that specific game — even if
+        they are playing in a different topic of the same chat.
+        """
+        game = self.game_for_chat_topic(chat.id, thread_id)
+        if game is None:
+            return None
+        for player in game.players:
+            if player.user.id == user.id:
                 return player
         return None
 
@@ -208,11 +242,6 @@ class GameManager(object):
         for (cid, _tid), game in self.chatid_games.items():
             if cid == chat_id:
                 yield game
-
-    def _any_game_in_chat(self, chat_id):
-        for game in self._games_in_chat(chat_id):
-            return game
-        return None
 
     def _forget_game(self, game):
         """Drop a game from all in-memory indexes and release its lock."""

--- a/internationalization.py
+++ b/internationalization.py
@@ -125,9 +125,11 @@ def user_locale(func):
         else:
             _.push('en_US')
 
-        result = await func(update, context, *pargs, **kwargs)
-        _.pop()
-        return result
+        try:
+            result = await func(update, context, *pargs, **kwargs)
+            return result
+        finally:
+            _.pop()
     return wrapped
 
 
@@ -154,12 +156,12 @@ def game_locales(func):
                 _.push(loc)
                 locales.append(loc)
 
-        result = await func(update, context, *pargs, **kwargs)
-
-        while _.code:
-            _.pop()
-
-        return result
+        try:
+            result = await func(update, context, *pargs, **kwargs)
+            return result
+        finally:
+            while _.code:
+                _.pop()
     return wrapped
 
 

--- a/internationalization.py
+++ b/internationalization.py
@@ -19,6 +19,7 @@
 
 
 import gettext
+from contextvars import ContextVar
 from functools import wraps
 
 from locales import available_locales
@@ -28,6 +29,8 @@ from shared_vars import gm
 
 GETTEXT_DOMAIN = 'unobot'
 GETTEXT_DIR = 'locales'
+
+_locale_stack: ContextVar[list] = ContextVar('locale_stack', default=[])
 
 
 class _Underscore(object):
@@ -43,27 +46,37 @@ class _Underscore(object):
             in available_locales.keys()
             if locale != 'en_US'  # No translation file for en_US
         }
-        self.locale_stack = list()
 
     def push(self, locale):
-        self.locale_stack.append(locale)
+        stack = _locale_stack.get([])
+        _locale_stack.set(stack + [locale])
 
     def pop(self):
-        if self.locale_stack:
-            return self.locale_stack.pop()
-        else:
-            return None
+        stack = _locale_stack.get([])
+        if stack:
+            locale = stack[-1]
+            _locale_stack.set(stack[:-1])
+            return locale
+        return None
 
     @property
     def code(self):
-        if self.locale_stack:
-            return self.locale_stack[-1]
-        else:
-            return None
+        stack = _locale_stack.get([])
+        if stack:
+            return stack[-1]
+        return None
+
+    @property
+    def locale_stack(self):
+        return _locale_stack.get([])
 
     def __call__(self, singular, plural=None, n=1, locale=None):
         if not locale:
-            locale = self.locale_stack[-1]
+            stack = _locale_stack.get([])
+            if stack:
+                locale = stack[-1]
+            else:
+                locale = 'en_US'
 
         if locale not in self.translators.keys():
             if n == 1:
@@ -84,12 +97,13 @@ _ = _Underscore()
 def __(singular, plural=None, n=1, multi=False):
     """Translates text into all locales on the stack"""
     translations = list()
+    stack = _locale_stack.get([])
 
-    if not multi and len(set(_.locale_stack)) >= 1:
+    if not multi and len(set(stack)) >= 1:
         translations.append(_(singular, plural, n, 'en_US'))
 
     else:
-        for locale in _.locale_stack:
+        for locale in stack:
             translation = _(singular, plural, n, locale)
 
             if translation not in translations:
@@ -100,8 +114,7 @@ def __(singular, plural=None, n=1, multi=False):
 
 def user_locale(func):
     @wraps(func)
-    @db_session
-    def wrapped(update, context, *pargs, **kwargs):
+    async def wrapped(update, context, *pargs, **kwargs):
         user = _user_chat_from_update(update)[0]
 
         with db_session:
@@ -112,7 +125,7 @@ def user_locale(func):
         else:
             _.push('en_US')
 
-        result = func(update, context, *pargs, **kwargs)
+        result = await func(update, context, *pargs, **kwargs)
         _.pop()
         return result
     return wrapped
@@ -120,15 +133,15 @@ def user_locale(func):
 
 def game_locales(func):
     @wraps(func)
-    @db_session
-    def wrapped(update, context, *pargs, **kwargs):
+    async def wrapped(update, context, *pargs, **kwargs):
         user, chat = _user_chat_from_update(update)
         player = gm.player_for_user_in_chat(user, chat)
         locales = list()
 
         if player:
             for player in player.game.players:
-                us = UserSetting.get(id=player.user.id)
+                with db_session:
+                    us = UserSetting.get(id=player.user.id)
 
                 if us and us.lang != 'en':
                     loc = us.lang
@@ -141,13 +154,18 @@ def game_locales(func):
                 _.push(loc)
                 locales.append(loc)
 
-        result = func(update, context, *pargs, **kwargs)
+        result = await func(update, context, *pargs, **kwargs)
 
         while _.code:
             _.pop()
 
         return result
     return wrapped
+
+
+def set_locale_stack(locales):
+    """Set the locale stack directly, for use in job callbacks"""
+    _locale_stack.set(list(locales))
 
 
 def _user_chat_from_update(update):

--- a/internationalization.py
+++ b/internationalization.py
@@ -116,6 +116,7 @@ def user_locale(func):
     @wraps(func)
     async def wrapped(update, context, *pargs, **kwargs):
         user = _user_chat_from_update(update)[0]
+        # chat and thread_id are unused here
 
         with db_session:
             us = UserSetting.get(id=user.id)
@@ -136,8 +137,9 @@ def user_locale(func):
 def game_locales(func):
     @wraps(func)
     async def wrapped(update, context, *pargs, **kwargs):
-        user, chat = _user_chat_from_update(update)
-        player = gm.player_for_user_in_chat(user, chat)
+        user, chat, thread_id = _user_chat_from_update(update)
+        player = gm.player_for_user_in_chat(user, chat, thread_id=thread_id) \
+            if chat is not None else None
         locales = list()
 
         if player:
@@ -173,8 +175,14 @@ def set_locale_stack(locales):
 def _user_chat_from_update(update):
     user = update.effective_user
     chat = update.effective_chat
+    msg = update.effective_message
+    thread_id = msg.message_thread_id if msg is not None else None
 
     if chat is None and user is not None and user.id in gm.userid_current:
-        chat = gm.userid_current.get(user.id).game.chat
+        # Inline-query path: borrow the chat from the user's currently active
+        # game so that the locale decorators have something to work with.
+        current_game = gm.userid_current[user.id].game
+        chat = current_game.chat
+        thread_id = current_game.thread_id
 
-    return user, chat
+    return user, chat, thread_id

--- a/internationalization.py
+++ b/internationalization.py
@@ -19,6 +19,7 @@
 
 
 import gettext
+from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import wraps
 
@@ -112,6 +113,28 @@ def __(singular, plural=None, n=1, multi=False):
     return '\n'.join(translations)
 
 
+@contextmanager
+def locale_stack(locales):
+    """Replace the current task's locale stack for the duration of the block,
+    restoring the previous stack on exit (even when the block raises).
+
+    Used by both :func:`game_locales` (decorator wrapping a request handler)
+    and :func:`actions.skip_job` (job-queue callback that re-enters with the
+    update's locale snapshot)."""
+    saved = _locale_stack.get([])
+    _locale_stack.set(list(locales))
+    try:
+        yield
+    finally:
+        _locale_stack.set(saved)
+
+
+def set_locale_stack(locales):
+    """Set the locale stack directly. Kept as a thin shim around the context
+    manager for callers that don't have a natural ``with``-scope."""
+    _locale_stack.set(list(locales))
+
+
 def user_locale(func):
     @wraps(func)
     async def wrapped(update, context, *pargs, **kwargs):
@@ -121,16 +144,10 @@ def user_locale(func):
         with db_session:
             us = UserSetting.get(id=user.id)
 
-        if us and us.lang != 'en':
-            _.push(us.lang)
-        else:
-            _.push('en_US')
-
-        try:
-            result = await func(update, context, *pargs, **kwargs)
-            return result
-        finally:
-            _.pop()
+        locale = us.lang if (us and us.lang != 'en') else 'en_US'
+        new_stack = _locale_stack.get([]) + [locale]
+        with locale_stack(new_stack):
+            return await func(update, context, *pargs, **kwargs)
     return wrapped
 
 
@@ -140,36 +157,19 @@ def game_locales(func):
         user, chat, thread_id = _user_chat_from_update(update)
         player = gm.player_for_user_in_chat(user, chat, thread_id=thread_id) \
             if chat is not None else None
-        locales = list()
 
+        new_stack = list(_locale_stack.get([]))
         if player:
-            for player in player.game.players:
+            for game_player in player.game.players:
                 with db_session:
-                    us = UserSetting.get(id=player.user.id)
+                    us = UserSetting.get(id=game_player.user.id)
+                loc = us.lang if (us and us.lang != 'en') else 'en_US'
+                if loc not in new_stack:
+                    new_stack.append(loc)
 
-                if us and us.lang != 'en':
-                    loc = us.lang
-                else:
-                    loc = 'en_US'
-
-                if loc in locales:
-                    continue
-
-                _.push(loc)
-                locales.append(loc)
-
-        try:
-            result = await func(update, context, *pargs, **kwargs)
-            return result
-        finally:
-            while _.code:
-                _.pop()
+        with locale_stack(new_stack):
+            return await func(update, context, *pargs, **kwargs)
     return wrapped
-
-
-def set_locale_stack(locales):
-    """Set the locale stack directly, for use in job callbacks"""
-    _locale_stack.set(list(locales))
 
 
 def _user_chat_from_update(update):

--- a/locales/unobot.pot
+++ b/locales/unobot.pot
@@ -268,6 +268,26 @@ msgid_plural "{name} ({number} cards)"
 msgstr[0] ""
 msgstr[1] ""
 
+#: bot.py:121
+msgid ""
+"There is already a game in this chat. End it with /kill before starting a "
+"new one."
+msgstr ""
+
+#: bot.py:796
+msgid "This game has already ended."
+msgstr ""
+
+#: bot.py:798
+msgid "You are no longer in this game."
+msgstr ""
+
+#: bot.py:800
+msgid ""
+"You are not in a game right now. Use /new to start one or /join to join an "
+"existing game."
+msgstr ""
+
 #: results.py:76
 msgid "You are not playing"
 msgstr ""

--- a/promotions.py
+++ b/promotions.py
@@ -21,10 +21,11 @@ def get_promotion():
     """ Get a random promotion message """
     return random.choices(list(PROMOTIONS.keys()), weights=list(PROMOTIONS.values()))[0]
 
-async def send_promotion(chat, chance=1.0):
+async def send_promotion(chat, chance=1.0, message_thread_id=None):
     """ (Maybe) send a promotion message """
     if random.random() <= chance:
         try:
-            await chat.send_message(get_promotion(), parse_mode='HTML')
+            await chat.send_message(get_promotion(), parse_mode='HTML',
+                                    message_thread_id=message_thread_id)
         except Exception as e:
             logger.exception(e)

--- a/promotions.py
+++ b/promotions.py
@@ -1,8 +1,11 @@
 """
 Promote other UNO bots
 """
+import logging
 import random
 
+
+logger = logging.getLogger(__name__)
 
 # Promotion messages and their weights
 PROMOTIONS = {
@@ -18,17 +21,10 @@ def get_promotion():
     """ Get a random promotion message """
     return random.choices(list(PROMOTIONS.keys()), weights=list(PROMOTIONS.values()))[0]
 
-def send_promotion(chat, chance=1.0):
+async def send_promotion(chat, chance=1.0):
     """ (Maybe) send a promotion message """
     if random.random() <= chance:
-        chat.send_message(get_promotion(), parse_mode='HTML')
-
-
-def send_promotion_async(chat, chance=1.0):
-    """ Send a promotion message asynchronously """
-
-    from utils import dispatcher, error
-    try:
-        dispatcher.run_async(send_promotion, chat, chance=chance)
-    except Exception as e:
-        error(None, None, e)
+        try:
+            await chat.send_message(get_promotion(), parse_mode='HTML')
+        except Exception as e:
+            logger.exception(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-telegram-bot==22.7
+python-telegram-bot[job-queue]==22.7
 pony==0.7.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-telegram-bot==13.15
+python-telegram-bot==22.7
 pony==0.7.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-telegram-bot[job-queue]==22.7
+python-telegram-bot[ext,http2]==22.7
 pony==0.7.19

--- a/result_id.py
+++ b/result_id.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Telegram bot to play UNO in group chats
+# Copyright (c) 2016 Jannes Höke <uno@jhoeke.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Encoding/decoding for inline-result IDs.
+
+Format: ``<game_id>:<base_id>:<anti_cheat>``
+``game_id`` is :class:`game.Game.id` (uuid hex), or :data:`PSEUDO_GAME_ID`
+("none") for results that do not belong to a specific game (mode picker, hand
+preview, no-game placeholder).
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+PSEUDO_GAME_ID = 'none'
+
+
+@dataclass(frozen=True)
+class DecodedResult:
+    game_id: str
+    base_id: str
+    anti_cheat: int
+
+
+def encode_result_id(*, game_id: str, base_id: str, anti_cheat: int) -> str:
+    return f'{game_id}:{base_id}:{anti_cheat}'
+
+
+def encode_results_list(results, *, game_id: str, anti_cheat: int) -> None:
+    """Re-encode every ``id`` in an inline-result list in-place.
+
+    Telegram inline-result objects are frozen in python-telegram-bot v22, so we
+    use their ``_unfrozen()`` context manager to mutate ``id``.
+    """
+    prefix = f'{game_id}:'
+    suffix = f':{anti_cheat}'
+    for result in results:
+        with result._unfrozen():
+            result.id = prefix + result.id + suffix
+
+
+def decode_result_id(result_id: str) -> Optional[DecodedResult]:
+    if not result_id:
+        return None
+    parts = result_id.split(':', 2)
+    if len(parts) != 3:
+        return None
+    game_id, base_id, anti_cheat_str = parts
+    if not game_id or not base_id:
+        return None
+    try:
+        anti_cheat = int(anti_cheat_str)
+    except ValueError:
+        return None
+    return DecodedResult(game_id=game_id, base_id=base_id, anti_cheat=anti_cheat)

--- a/result_id_resolver.py
+++ b/result_id_resolver.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Telegram bot to play UNO in group chats
+# Copyright (c) 2016 Jannes Höke <uno@jhoeke.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Map a decoded inline-result ID + user to a game/player, or to a structured
+"dead-game" reason the handler can surface to the user (AC-8)."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from result_id import DecodedResult, PSEUDO_GAME_ID
+
+
+DEAD_NO_CURRENT_GAME = 'no_current_game'
+DEAD_UNKNOWN_GAME = 'unknown_game'
+DEAD_NOT_A_PLAYER = 'not_a_player'
+
+
+@dataclass
+class ResolvedResult:
+    game: Optional[object]
+    player: Optional[object]
+    dead_reason: Optional[str]
+
+
+def resolve_result(gm, decoded: DecodedResult, user_id: int) -> ResolvedResult:
+    """Return the (game, player) pair for this decoded result, or a dead reason.
+
+    The handler presents ``dead_reason`` to the user so that no inline selection
+    disappears silently when the game has ended mid-interaction.
+    """
+    if decoded.game_id == PSEUDO_GAME_ID:
+        player = gm.userid_current.get(user_id)
+        if player is None:
+            return ResolvedResult(game=None, player=None,
+                                  dead_reason=DEAD_NO_CURRENT_GAME)
+        return ResolvedResult(game=player.game, player=player, dead_reason=None)
+
+    game = gm.game_by_id(decoded.game_id)
+    if game is None:
+        return ResolvedResult(game=None, player=None,
+                              dead_reason=DEAD_UNKNOWN_GAME)
+
+    for player in game.players:
+        if player.user.id == user_id:
+            return ResolvedResult(game=game, player=player, dead_reason=None)
+
+    return ResolvedResult(game=game, player=None, dead_reason=DEAD_NOT_A_PLAYER)

--- a/settings.py
+++ b/settings.py
@@ -19,21 +19,21 @@
 
 
 from telegram import ReplyKeyboardMarkup, Update
-from telegram.ext import CommandHandler, Filters, MessageHandler, CallbackContext
+from telegram.ext import CommandHandler, filters, MessageHandler, ContextTypes
 
 from utils import send_async
 from user_setting import UserSetting
-from shared_vars import dispatcher
+from shared_vars import application
 from locales import available_locales
 from internationalization import _, user_locale
 
 
 @user_locale
-def show_settings(update: Update, context: CallbackContext):
+async def show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE):
     chat = update.message.chat
 
     if update.message.chat.type != 'private':
-        send_async(context.bot, chat.id,
+        await send_async(context.bot, chat.id,
                    text=_("Please edit your settings in a private chat with "
                           "the bot."))
         return
@@ -49,13 +49,13 @@ def show_settings(update: Update, context: CallbackContext):
         stats = '❌' + ' ' + _("Delete all statistics")
 
     kb = [[stats], ['🌍' + ' ' + _("Language")]]
-    send_async(context.bot, chat.id, text='🔧' + ' ' + _("Settings"),
+    await send_async(context.bot, chat.id, text='🔧' + ' ' + _("Settings"),
                reply_markup=ReplyKeyboardMarkup(keyboard=kb,
                                                 one_time_keyboard=True))
 
 
 @user_locale
-def kb_select(update: Update, context: CallbackContext):
+async def kb_select(update: Update, context: ContextTypes.DEFAULT_TYPE):
     chat = update.message.chat
     user = update.message.from_user
     option = context.match[1]
@@ -63,13 +63,13 @@ def kb_select(update: Update, context: CallbackContext):
     if option == '📊':
         us = UserSetting.get(id=user.id)
         us.stats = True
-        send_async(context.bot, chat.id, text=_("Enabled statistics!"))
+        await send_async(context.bot, chat.id, text=_("Enabled statistics!"))
 
     elif option == '🌍':
         kb = [[locale + ' - ' + descr]
               for locale, descr
               in sorted(available_locales.items())]
-        send_async(context.bot, chat.id, text=_("Select locale"),
+        await send_async(context.bot, chat.id, text=_("Select locale"),
                    reply_markup=ReplyKeyboardMarkup(keyboard=kb,
                                                     one_time_keyboard=True))
 
@@ -79,11 +79,11 @@ def kb_select(update: Update, context: CallbackContext):
         us.first_places = 0
         us.games_played = 0
         us.cards_played = 0
-        send_async(context.bot, chat.id, text=_("Deleted and disabled statistics!"))
+        await send_async(context.bot, chat.id, text=_("Deleted and disabled statistics!"))
 
 
 @user_locale
-def locale_select(update: Update, context: CallbackContext):
+async def locale_select(update: Update, context: ContextTypes.DEFAULT_TYPE):
     chat = update.message.chat
     user = update.message.from_user
     option = context.match[1]
@@ -92,14 +92,14 @@ def locale_select(update: Update, context: CallbackContext):
         us = UserSetting.get(id=user.id)
         us.lang = option
         _.push(option)
-        send_async(context.bot, chat.id, text=_("Set locale!"))
+        await send_async(context.bot, chat.id, text=_("Set locale!"))
         _.pop()
 
 def register():
-    dispatcher.add_handler(CommandHandler('settings', show_settings))
-    dispatcher.add_handler(MessageHandler(Filters.regex('^([' + '📊' +
+    application.add_handler(CommandHandler('settings', show_settings))
+    application.add_handler(MessageHandler(filters.Regex('^([' + '📊' +
                                                         '🌍' +
                                                         '❌' + ']) .+$'),
                                         kb_select))
-    dispatcher.add_handler(MessageHandler(Filters.regex(r'^(\w\w_\w\w) - .*'),
+    application.add_handler(MessageHandler(filters.Regex(r'^(\w\w_\w\w) - .*'),
                                         locale_select))

--- a/settings.py
+++ b/settings.py
@@ -21,6 +21,7 @@
 from telegram import ReplyKeyboardMarkup, Update
 from telegram.ext import CommandHandler, filters, MessageHandler, ContextTypes
 
+from pony.orm import db_session
 from utils import send_async
 from user_setting import UserSetting
 from shared_vars import application
@@ -38,15 +39,16 @@ async def show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE):
                           "the bot."))
         return
 
-    us = UserSetting.get(id=update.message.from_user.id)
+    with db_session:
+        us = UserSetting.get(id=update.message.from_user.id)
 
-    if not us:
-        us = UserSetting(id=update.message.from_user.id)
+        if not us:
+            us = UserSetting(id=update.message.from_user.id)
 
-    if not us.stats:
-        stats = '📊' + ' ' + _("Enable statistics")
-    else:
-        stats = '❌' + ' ' + _("Delete all statistics")
+        if not us.stats:
+            stats = '📊' + ' ' + _("Enable statistics")
+        else:
+            stats = '❌' + ' ' + _("Delete all statistics")
 
     kb = [[stats], ['🌍' + ' ' + _("Language")]]
     await send_async(context.bot, chat.id, text='🔧' + ' ' + _("Settings"),
@@ -61,8 +63,9 @@ async def kb_select(update: Update, context: ContextTypes.DEFAULT_TYPE):
     option = context.match[1]
 
     if option == '📊':
-        us = UserSetting.get(id=user.id)
-        us.stats = True
+        with db_session:
+            us = UserSetting.get(id=user.id)
+            us.stats = True
         await send_async(context.bot, chat.id, text=_("Enabled statistics!"))
 
     elif option == '🌍':
@@ -74,11 +77,12 @@ async def kb_select(update: Update, context: ContextTypes.DEFAULT_TYPE):
                                                     one_time_keyboard=True))
 
     elif option == '❌':
-        us = UserSetting.get(id=user.id)
-        us.stats = False
-        us.first_places = 0
-        us.games_played = 0
-        us.cards_played = 0
+        with db_session:
+            us = UserSetting.get(id=user.id)
+            us.stats = False
+            us.first_places = 0
+            us.games_played = 0
+            us.cards_played = 0
         await send_async(context.bot, chat.id, text=_("Deleted and disabled statistics!"))
 
 
@@ -89,8 +93,9 @@ async def locale_select(update: Update, context: ContextTypes.DEFAULT_TYPE):
     option = context.match[1]
 
     if option in available_locales:
-        us = UserSetting.get(id=user.id)
-        us.lang = option
+        with db_session:
+            us = UserSetting.get(id=user.id)
+            us.lang = option
         _.push(option)
         await send_async(context.bot, chat.id, text=_("Set locale!"))
         _.pop()

--- a/shared_vars.py
+++ b/shared_vars.py
@@ -46,7 +46,12 @@ update_processor = UnoUpdateProcessor(
 )
 gm.update_processor = update_processor
 
+_TIMEOUT = 2.5  # aggressive default, matches pre-v22 behaviour
+
 application = (Application.builder()
                .token(TOKEN)
                .concurrent_updates(update_processor)
+               .read_timeout(_TIMEOUT)
+               .write_timeout(_TIMEOUT)
+               .connect_timeout(_TIMEOUT)
                .build())

--- a/shared_vars.py
+++ b/shared_vars.py
@@ -18,10 +18,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-from config import TOKEN, WORKERS
+from config import TOKEN
 import logging
 import os
-from telegram.ext import Updater
+from telegram.ext import Application
 
 from game_manager import GameManager
 from database import db
@@ -30,5 +30,4 @@ db.bind('sqlite', os.getenv('UNO_DB', 'uno.sqlite3'), create_db=True)
 db.generate_mapping(create_tables=True)
 
 gm = GameManager()
-updater = Updater(token=TOKEN, workers=WORKERS, use_context=True)
-dispatcher = updater.dispatcher
+application = Application.builder().token(TOKEN).concurrent_updates(True).build()

--- a/shared_vars.py
+++ b/shared_vars.py
@@ -19,15 +19,34 @@
 
 
 from config import TOKEN
-import logging
 import os
 from telegram.ext import Application
 
-from game_manager import GameManager
 from database import db
+from game_manager import GameManager
+from uno_update_processor import UnoUpdateProcessor
 
 db.bind('sqlite', os.getenv('UNO_DB', 'uno.sqlite3'), create_db=True)
 db.generate_mapping(create_tables=True)
 
 gm = GameManager()
-application = Application.builder().token(TOKEN).concurrent_updates(True).build()
+
+
+def _resolve_game_id(game_id):
+    """Map a Game.id back to (chat_id, thread_id) for UpdateProcessor routing."""
+    game = gm.game_by_id(game_id)
+    if game is None:
+        return None
+    return (game.chat.id, game.thread_id)
+
+
+update_processor = UnoUpdateProcessor(
+    max_concurrent_updates=256,
+    game_resolver=_resolve_game_id,
+)
+gm.update_processor = update_processor
+
+application = (Application.builder()
+               .token(TOKEN)
+               .concurrent_updates(update_processor)
+               .build())

--- a/simple_commands.py
+++ b/simple_commands.py
@@ -17,17 +17,18 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from telegram import ParseMode, Update
-from telegram.ext import CommandHandler, CallbackContext
+from telegram import Update
+from telegram.constants import ParseMode
+from telegram.ext import CommandHandler, ContextTypes
 
 from user_setting import UserSetting
 from utils import send_async
-from shared_vars import dispatcher
+from shared_vars import application
 from internationalization import _, user_locale
 from promotions import send_promotion
 
 @user_locale
-def help_handler(update: Update, context: CallbackContext):
+async def help_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /help command"""
     help_text = _("Follow these steps:\n\n"
       "1. Add this bot to a group\n"
@@ -65,19 +66,17 @@ def help_handler(update: Update, context: CallbackContext):
       "<a href=\"https://telegram.me/unobotnews\">update channel</a>"
       " and buy an UNO card game.")
 
-    def _send():
-      update.message.chat.send_message(
-          help_text,
-          parse_mode=ParseMode.HTML,
-          disable_web_page_preview=True,
-      )
-      send_promotion(update.effective_chat)
-
-    context.dispatcher.run_async(_send)
+    await context.bot.send_message(
+        update.message.chat_id,
+        help_text,
+        parse_mode=ParseMode.HTML,
+        disable_web_page_preview=True,
+    )
+    await send_promotion(update.effective_chat)
 
 @user_locale
-def modes(update: Update, context: CallbackContext):
-    """Handler for the /help command"""
+async def modes(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handler for the /modes command"""
     modes_explanation = _("This UNO bot has four game modes: Classic, Sanic, Wild and Text.\n\n"
       " 🎻 The Classic mode uses the conventional UNO deck and there is no auto skip.\n"
       " 🚀 The Sanic mode uses the conventional UNO deck and the bot automatically skips a player if he/she takes too long to play its turn\n"
@@ -85,12 +84,12 @@ def modes(update: Update, context: CallbackContext):
       " ✍️ The Text mode uses the conventional UNO deck but instead of stickers it uses the text.\n\n"
       "To change the game mode, the GAME CREATOR has to type the bot nickname and a space, "
       "just like when playing a card, and all gamemode options should appear.")
-    send_async(context.bot, update.message.chat_id, text=modes_explanation,
+    await send_async(context.bot, update.message.chat_id, text=modes_explanation,
                parse_mode=ParseMode.HTML, disable_web_page_preview=True)
 
 @user_locale
-def source(update: Update, context: CallbackContext):
-    """Handler for the /help command"""
+async def source(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handler for the /source command"""
     source_text = _("This bot is Free Software and licensed under the AGPL. "
       "The code is available here: \n"
       "https://github.com/jh0ker/mau_mau_bot")
@@ -102,25 +101,25 @@ def source(update: Update, context: CallbackContext):
       "Originals available on http://game-icons.net\n"
       "Icons edited by ɳick")
 
-    send_async(context.bot, update.message.chat_id, text=source_text + '\n' +
+    await send_async(context.bot, update.message.chat_id, text=source_text + '\n' +
                                                  attributions,
                parse_mode=ParseMode.HTML, disable_web_page_preview=True)
 
 
 @user_locale
-def news(update: Update, context: CallbackContext):
+async def news(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /news command"""
-    send_async(context.bot, update.message.chat_id,
+    await send_async(context.bot, update.message.chat_id,
                text=_("All news here: https://telegram.me/unobotnews"),
                disable_web_page_preview=True)
 
 
 @user_locale
-def stats(update: Update, context: CallbackContext):
+async def stats(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user = update.message.from_user
     us = UserSetting.get(id=user.id)
     if not us or not us.stats:
-        send_async(context.bot, update.message.chat_id,
+        await send_async(context.bot, update.message.chat_id,
                    text=_("You did not enable statistics. Use /settings in "
                           "a private chat with the bot to enable them."))
     else:
@@ -148,13 +147,13 @@ def stats(update: Update, context: CallbackContext):
               n).format(number=n)
         )
 
-        send_async(context.bot, update.message.chat_id,
+        await send_async(context.bot, update.message.chat_id,
                    text='\n'.join(stats_text))
 
 
 def register():
-    dispatcher.add_handler(CommandHandler('help', help_handler))
-    dispatcher.add_handler(CommandHandler('source', source))
-    dispatcher.add_handler(CommandHandler('news', news))
-    dispatcher.add_handler(CommandHandler('stats', stats))
-    dispatcher.add_handler(CommandHandler('modes', modes))
+    application.add_handler(CommandHandler('help', help_handler))
+    application.add_handler(CommandHandler('source', source))
+    application.add_handler(CommandHandler('news', news))
+    application.add_handler(CommandHandler('stats', stats))
+    application.add_handler(CommandHandler('modes', modes))

--- a/simple_commands.py
+++ b/simple_commands.py
@@ -21,6 +21,7 @@ from telegram import Update
 from telegram.constants import ParseMode
 from telegram.ext import CommandHandler, ContextTypes
 
+from pony.orm import db_session
 from user_setting import UserSetting
 from utils import send_async
 from shared_vars import application
@@ -117,30 +118,39 @@ async def news(update: Update, context: ContextTypes.DEFAULT_TYPE):
 @user_locale
 async def stats(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user = update.message.from_user
-    us = UserSetting.get(id=user.id)
-    if not us or not us.stats:
+    with db_session:
+        us = UserSetting.get(id=user.id)
+        if not us or not us.stats:
+            no_stats = True
+        else:
+            no_stats = False
+            games_played = us.games_played
+            first_places = us.first_places
+            cards_played = us.cards_played
+
+    if no_stats:
         await send_async(context.bot, update.message.chat_id,
                    text=_("You did not enable statistics. Use /settings in "
                           "a private chat with the bot to enable them."))
     else:
         stats_text = list()
 
-        n = us.games_played
+        n = games_played
         stats_text.append(
             _("{number} game played",
               "{number} games played",
               n).format(number=n)
         )
 
-        n = us.first_places
-        m = round((us.first_places / us.games_played) * 100) if us.games_played else 0
+        n = first_places
+        m = round((first_places / games_played) * 100) if games_played else 0
         stats_text.append(
             _("{number} first place ({percent}%)",
               "{number} first places ({percent}%)",
               n).format(number=n, percent=m)
         )
 
-        n = us.cards_played
+        n = cards_played
         stats_text.append(
             _("{number} card played",
               "{number} cards played",

--- a/simple_commands.py
+++ b/simple_commands.py
@@ -72,6 +72,7 @@ async def help_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         help_text,
         parse_mode=ParseMode.HTML,
         disable_web_page_preview=True,
+        message_thread_id=update.message.message_thread_id,
     )
     await send_promotion(update.effective_chat)
 
@@ -86,7 +87,8 @@ async def modes(update: Update, context: ContextTypes.DEFAULT_TYPE):
       "To change the game mode, the GAME CREATOR has to type the bot nickname and a space, "
       "just like when playing a card, and all gamemode options should appear.")
     await send_async(context.bot, update.message.chat_id, text=modes_explanation,
-               parse_mode=ParseMode.HTML, disable_web_page_preview=True)
+               parse_mode=ParseMode.HTML, disable_web_page_preview=True,
+               message_thread_id=update.message.message_thread_id)
 
 @user_locale
 async def source(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -104,7 +106,8 @@ async def source(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     await send_async(context.bot, update.message.chat_id, text=source_text + '\n' +
                                                  attributions,
-               parse_mode=ParseMode.HTML, disable_web_page_preview=True)
+               parse_mode=ParseMode.HTML, disable_web_page_preview=True,
+               message_thread_id=update.message.message_thread_id)
 
 
 @user_locale
@@ -112,7 +115,8 @@ async def news(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handler for the /news command"""
     await send_async(context.bot, update.message.chat_id,
                text=_("All news here: https://telegram.me/unobotnews"),
-               disable_web_page_preview=True)
+               disable_web_page_preview=True,
+               message_thread_id=update.message.message_thread_id)
 
 
 @user_locale
@@ -131,7 +135,8 @@ async def stats(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if no_stats:
         await send_async(context.bot, update.message.chat_id,
                    text=_("You did not enable statistics. Use /settings in "
-                          "a private chat with the bot to enable them."))
+                          "a private chat with the bot to enable them."),
+                   message_thread_id=update.message.message_thread_id)
     else:
         stats_text = list()
 
@@ -158,7 +163,8 @@ async def stats(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
 
         await send_async(context.bot, update.message.chat_id,
-                   text='\n'.join(stats_text))
+                   text='\n'.join(stats_text),
+                   message_thread_id=update.message.message_thread_id)
 
 
 def register():

--- a/simple_commands.py
+++ b/simple_commands.py
@@ -74,7 +74,8 @@ async def help_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         disable_web_page_preview=True,
         message_thread_id=update.message.message_thread_id,
     )
-    await send_promotion(update.effective_chat)
+    await send_promotion(update.effective_chat,
+                         message_thread_id=update.message.message_thread_id)
 
 @user_locale
 async def modes(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/start_bot.py
+++ b/start_bot.py
@@ -21,5 +21,5 @@
 # a Webhook
 
 
-def start_bot(updater):
-    updater.start_polling()
+def start_bot(application):
+    application.run_polling()

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -41,8 +41,6 @@ class TestGameLock:
         """Two concurrent turn() calls should advance by exactly 2 positions"""
         initial_player = self.game.current_player
 
-        barrier = asyncio.Event()
-
         async def turn_with_lock(ready_event):
             ready_event.set()
             async with self.game.lock:

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -18,79 +18,30 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-import asyncio
-import pytest
+"""After UNO-12 the per-Game lock and per-chat lock are gone — locking is
+centralised in :class:`uno_update_processor.UnoUpdateProcessor`, which has its
+own dedicated test suite. This file pins the *removal* so that nobody
+accidentally re-introduces those locks via merge."""
 
 from game import Game
 from game_manager import GameManager
 from player import Player
 
 
-class TestGameLock:
-    """Tests that Game.lock serializes concurrent state mutations"""
+class TestLocksAreRemoved:
+    """Per-Game and per-chat asyncio.Locks must not exist any more."""
 
-    def setup_method(self):
-        self.game = Game(None)
-        p0 = Player(self.game, "Player 0")
-        p1 = Player(self.game, "Player 1")
-        p2 = Player(self.game, "Player 2")
-        self.game.start()
+    def test_game_has_no_lock_attribute(self):
+        game = Game(None)
+        Player(game, 'p0')
+        Player(game, 'p1')
+        Player(game, 'p2')
+        assert not hasattr(game, 'lock'), \
+            "Game.lock must be removed — locking lives in UnoUpdateProcessor"
 
-    @pytest.mark.asyncio
-    async def test_concurrent_turns_are_serialized(self):
-        """Two concurrent turn() calls should advance by exactly 2 positions"""
-        initial_player = self.game.current_player
-
-        async def turn_with_lock(ready_event):
-            ready_event.set()
-            async with self.game.lock:
-                self.game.turn()
-
-        ready1 = asyncio.Event()
-        ready2 = asyncio.Event()
-
-        task1 = asyncio.create_task(turn_with_lock(ready1))
-        task2 = asyncio.create_task(turn_with_lock(ready2))
-
-        await asyncio.gather(task1, task2)
-
-        # After two serialized turns, we should be 2 positions ahead
-        expected = initial_player.next.next
-        assert self.game.current_player == expected
-
-    @pytest.mark.asyncio
-    async def test_lock_is_per_game_instance(self):
-        """Different games should have independent locks"""
-        game2 = Game(None)
-        Player(game2, "Player A")
-        Player(game2, "Player B")
-        game2.start()
-
-        assert self.game.lock is not game2.lock
-
-        # Both locks can be acquired concurrently without deadlock
-        async with self.game.lock:
-            async with game2.lock:
-                self.game.turn()
-                game2.turn()
-
-
-class TestChatLock:
-    """Tests that GameManager.chat_locks provides per-chat locking"""
-
-    def setup_method(self):
-        self.gm = GameManager()
-
-    def test_same_chat_returns_same_lock(self):
-        lock1 = self.gm.get_chat_lock(123)
-        lock2 = self.gm.get_chat_lock(123)
-        assert lock1 is lock2
-
-    def test_different_chats_return_different_locks(self):
-        lock1 = self.gm.get_chat_lock(123)
-        lock2 = self.gm.get_chat_lock(456)
-        assert lock1 is not lock2
-
-    def test_lock_is_asyncio_lock(self):
-        lock = self.gm.get_chat_lock(789)
-        assert isinstance(lock, asyncio.Lock)
+    def test_game_manager_has_no_chat_locks(self):
+        gm = GameManager()
+        assert not hasattr(gm, 'chat_locks'), \
+            "GameManager.chat_locks must be removed — UnoUpdateProcessor owns the locks"
+        assert not hasattr(gm, 'get_chat_lock'), \
+            "GameManager.get_chat_lock must be removed"

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Telegram bot to play UNO in group chats
+# Copyright (c) 2016 Jannes Höke <uno@jhoeke.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+import asyncio
+import pytest
+
+from game import Game
+from game_manager import GameManager
+from player import Player
+
+
+class TestGameLock:
+    """Tests that Game.lock serializes concurrent state mutations"""
+
+    def setup_method(self):
+        self.game = Game(None)
+        p0 = Player(self.game, "Player 0")
+        p1 = Player(self.game, "Player 1")
+        p2 = Player(self.game, "Player 2")
+        self.game.start()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_turns_are_serialized(self):
+        """Two concurrent turn() calls should advance by exactly 2 positions"""
+        initial_player = self.game.current_player
+
+        barrier = asyncio.Event()
+
+        async def turn_with_lock(ready_event):
+            ready_event.set()
+            async with self.game.lock:
+                self.game.turn()
+
+        ready1 = asyncio.Event()
+        ready2 = asyncio.Event()
+
+        task1 = asyncio.create_task(turn_with_lock(ready1))
+        task2 = asyncio.create_task(turn_with_lock(ready2))
+
+        await asyncio.gather(task1, task2)
+
+        # After two serialized turns, we should be 2 positions ahead
+        expected = initial_player.next.next
+        assert self.game.current_player == expected
+
+    @pytest.mark.asyncio
+    async def test_lock_is_per_game_instance(self):
+        """Different games should have independent locks"""
+        game2 = Game(None)
+        Player(game2, "Player A")
+        Player(game2, "Player B")
+        game2.start()
+
+        assert self.game.lock is not game2.lock
+
+        # Both locks can be acquired concurrently without deadlock
+        async with self.game.lock:
+            async with game2.lock:
+                self.game.turn()
+                game2.turn()
+
+
+class TestChatLock:
+    """Tests that GameManager.chat_locks provides per-chat locking"""
+
+    def setup_method(self):
+        self.gm = GameManager()
+
+    def test_same_chat_returns_same_lock(self):
+        lock1 = self.gm.get_chat_lock(123)
+        lock2 = self.gm.get_chat_lock(123)
+        assert lock1 is lock2
+
+    def test_different_chats_return_different_locks(self):
+        lock1 = self.gm.get_chat_lock(123)
+        lock2 = self.gm.get_chat_lock(456)
+        assert lock1 is not lock2
+
+    def test_lock_is_asyncio_lock(self):
+        lock = self.gm.get_chat_lock(789)
+        assert isinstance(lock, asyncio.Lock)

--- a/test/test_error_handler.py
+++ b/test/test_error_handler.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Telegram bot to play UNO in group chats
+# Copyright (c) 2016 Jannes Höke <uno@jhoeke.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Tests for utils.error — addresses Copilot's utils.py:84 finding on PR #138:
+``logger.exception(context.error)`` outside an active exception context logs
+``NoneType: None`` instead of the real traceback."""
+
+import logging
+import os
+import sys
+import types
+
+import pytest
+
+# Stub config + DB env before importing utils (which pulls shared_vars)
+if 'config' not in sys.modules:
+    fake_config = types.ModuleType('config')
+    for k, v in [('TOKEN', '0:abc'), ('WORKERS', 0), ('ADMIN_LIST', []),
+                 ('OPEN_LOBBY', True), ('DEFAULT_GAMEMODE', 'classic'),
+                 ('ENABLE_TRANSLATIONS', False), ('WAITING_TIME', 90),
+                 ('MIN_PLAYERS', 2), ('TIME_REMOVAL_AFTER_SKIP', 20),
+                 ('MIN_FAST_TURN_TIME', 8), ('BOT_USERNAME', 'm')]:
+        setattr(fake_config, k, v)
+    sys.modules['config'] = fake_config
+os.environ.setdefault('UNO_DB', ':memory:')
+
+from utils import error
+
+
+class _FakeContext:
+    def __init__(self, exc):
+        self.error = exc
+
+
+@pytest.mark.asyncio
+async def test_error_logs_real_traceback_when_context_has_error(caplog):
+    """When PTB hands us the original exception, the log record must carry
+    its traceback (not 'NoneType: None')."""
+    exc = ValueError("boom: real exception")
+
+    with caplog.at_level(logging.ERROR, logger='utils'):
+        await error(update=None, context=_FakeContext(exc))
+
+    assert len(caplog.records) == 1
+    rec = caplog.records[0]
+    # exc_info must carry the exception object so the formatter can render the
+    # real traceback. Plain logger.exception() outside `except` produces None.
+    assert rec.exc_info is not None, \
+        "error() must attach exc_info so the traceback is logged"
+    assert rec.exc_info[1] is exc, \
+        "exc_info[1] should be the original exception instance"
+
+
+@pytest.mark.asyncio
+async def test_error_handles_context_without_error_field(caplog):
+    """Some PTB error scenarios pass a context whose .error is None. The
+    handler must not crash and must still log something useful."""
+    with caplog.at_level(logging.ERROR, logger='utils'):
+        await error(update=None, context=_FakeContext(None))
+
+    assert len(caplog.records) == 1
+    # No exc_info expected when there is no exception to attach
+    assert caplog.records[0].exc_info is None

--- a/test/test_game_manager.py
+++ b/test/test_game_manager.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
+import asyncio
 import unittest
 
 from telegram import User, Chat
@@ -38,9 +39,9 @@ class Test(unittest.TestCase):
         self.chat1 = Chat(1, 'group')
         self.chat2 = Chat(2, 'group')
 
-        self.user0 = User(0, 'user0')
-        self.user1 = User(1, 'user1')
-        self.user2 = User(2, 'user2')
+        self.user0 = User(0, 'user0', is_bot=False)
+        self.user1 = User(1, 'user1', is_bot=False)
+        self.user2 = User(2, 'user2', is_bot=False)
 
     def test_new_game(self):
         g0 = self.gm.new_game(self.chat0)
@@ -101,10 +102,10 @@ class Test(unittest.TestCase):
         self.gm.new_game(self.chat0)
         self.gm.join_game(self.user2, self.chat0)
 
-        self.gm.end_game(self.chat0, self.user0)
+        asyncio.run(self.gm.end_game(self.chat0, self.user0))
         self.assertEqual(len(self.gm.chatid_games[0]), 1)
 
-        self.gm.end_game(self.chat0, self.user2)
+        asyncio.run(self.gm.end_game(self.chat0, self.user2))
         self.assertFalse(0 in self.gm.chatid_games)
         self.assertFalse(0 in self.gm.userid_players)
         self.assertFalse(1 in self.gm.userid_players)

--- a/test/test_game_manager.py
+++ b/test/test_game_manager.py
@@ -18,7 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-import asyncio
 import unittest
 
 from telegram import User, Chat
@@ -102,10 +101,10 @@ class Test(unittest.TestCase):
         self.gm.new_game(self.chat0)
         self.gm.join_game(self.user2, self.chat0)
 
-        asyncio.run(self.gm.end_game(self.chat0, self.user0))
+        self.gm.end_game(self.chat0, self.user0)
         self.assertEqual(len(self.gm.chatid_games[0]), 1)
 
-        asyncio.run(self.gm.end_game(self.chat0, self.user2))
+        self.gm.end_game(self.chat0, self.user2)
         self.assertFalse(0 in self.gm.chatid_games)
         self.assertFalse(0 in self.gm.userid_players)
         self.assertFalse(1 in self.gm.userid_players)

--- a/test/test_game_manager.py
+++ b/test/test_game_manager.py
@@ -23,13 +23,12 @@ import unittest
 from telegram import User, Chat
 
 from game_manager import GameManager
-from errors import AlreadyJoinedError, LobbyClosedError, NoGameInChatError, \
-    NotEnoughPlayersError
+from errors import (AlreadyJoinedError, GameAlreadyRunningError,
+                    LobbyClosedError, NoGameInChatError, NotEnoughPlayersError)
 
 
 class Test(unittest.TestCase):
-
-    game = None
+    """Tests for the singleton (chat_id, thread_id) -> Game model."""
 
     def setUp(self):
         self.gm = GameManager()
@@ -42,15 +41,57 @@ class Test(unittest.TestCase):
         self.user1 = User(1, 'user1', is_bot=False)
         self.user2 = User(2, 'user2', is_bot=False)
 
-    def test_new_game(self):
+    # AC-3, AC-4: chatid_games is a (chat_id, thread_id) -> Game dict
+    def test_new_game_stores_singleton_per_chat_topic(self):
         g0 = self.gm.new_game(self.chat0)
         g1 = self.gm.new_game(self.chat1)
 
-        self.assertListEqual(self.gm.chatid_games[0], [g0])
-        self.assertListEqual(self.gm.chatid_games[1], [g1])
+        self.assertIs(self.gm.chatid_games[(0, None)], g0)
+        self.assertIs(self.gm.chatid_games[(1, None)], g1)
 
+    # AC-1, AC-2: second new_game in the same (chat, topic) with a joined
+    # player raises. An empty stale lobby may be silently replaced (UX parity
+    # with the previous "remove old games without players" behaviour).
+    def test_new_game_raises_when_topic_has_active_lobby(self):
+        self.gm.new_game(self.chat0)
+        self.gm.join_game(self.user0, self.chat0)
+        with self.assertRaises(GameAlreadyRunningError):
+            self.gm.new_game(self.chat0)
+
+    def test_new_game_replaces_empty_stale_lobby(self):
+        first = self.gm.new_game(self.chat0)
+        second = self.gm.new_game(self.chat0)
+        self.assertIsNot(first, second)
+        self.assertIs(self.gm.chatid_games[(0, None)], second)
+        self.assertNotIn(first.id, self.gm.games_by_id)
+
+    # AC-1: same chat but different topics is allowed
+    def test_new_game_allows_separate_topics_in_same_chat(self):
+        g_main = self.gm.new_game(self.chat0)
+        g_topic = self.gm.new_game(self.chat0, thread_id=42)
+
+        self.assertIs(self.gm.chatid_games[(0, None)], g_main)
+        self.assertIs(self.gm.chatid_games[(0, 42)], g_topic)
+        self.assertIsNot(g_main, g_topic)
+        self.assertEqual(g_topic.thread_id, 42)
+
+    def test_game_for_chat_topic_returns_correct_game(self):
+        g_main = self.gm.new_game(self.chat0)
+        g_topic = self.gm.new_game(self.chat0, thread_id=7)
+
+        self.assertIs(self.gm.game_for_chat_topic(0, None), g_main)
+        self.assertIs(self.gm.game_for_chat_topic(0, 7), g_topic)
+        self.assertIsNone(self.gm.game_for_chat_topic(0, 999))
+        self.assertIsNone(self.gm.game_for_chat_topic(99, None))
+
+    # AC-7: game_by_id resolves the game from a result_id prefix
+    def test_game_by_id_resolves_game(self):
+        g = self.gm.new_game(self.chat0)
+        self.assertIs(self.gm.game_by_id(g.id), g)
+        self.assertIsNone(self.gm.game_by_id('does-not-exist'))
+
+    # Joining still works through the (chat, topic) lookup
     def test_join_game(self):
-
         self.assertRaises(NoGameInChatError,
                           self.gm.join_game,
                           *(self.user0, self.chat0))
@@ -90,22 +131,39 @@ class Test(unittest.TestCase):
                           self.gm.leave_game,
                           *(self.user0, self.chat0))
 
-    def test_end_game(self):
+    def test_end_game_clears_singleton(self):
         self.gm.new_game(self.chat0)
-
         self.gm.join_game(self.user0, self.chat0)
         self.gm.join_game(self.user1, self.chat0)
 
         self.assertEqual(len(self.gm.userid_players[0]), 1)
 
-        self.gm.new_game(self.chat0)
-        self.gm.join_game(self.user2, self.chat0)
-
         self.gm.end_game(self.chat0, self.user0)
-        self.assertEqual(len(self.gm.chatid_games[0]), 1)
+        self.assertNotIn((0, None), self.gm.chatid_games)
+        self.assertNotIn(0, self.gm.userid_players)
+        self.assertNotIn(1, self.gm.userid_players)
 
-        self.gm.end_game(self.chat0, self.user2)
-        self.assertFalse(0 in self.gm.chatid_games)
-        self.assertFalse(0 in self.gm.userid_players)
-        self.assertFalse(1 in self.gm.userid_players)
-        self.assertFalse(2 in self.gm.userid_players)
+    def test_end_game_releases_processor_lock_when_registered(self):
+        """end_game should call processor.release_key for cleanup."""
+        released = []
+
+        class FakeProcessor:
+            def release_key(self, key):
+                released.append(key)
+
+        self.gm.update_processor = FakeProcessor()
+
+        g = self.gm.new_game(self.chat0, thread_id=11)
+        self.gm.join_game(self.user0, self.chat0)
+        self.gm.join_game(self.user1, self.chat0)
+        self.gm.end_game(self.chat0, self.user0)
+
+        self.assertEqual(released, [(0, 11)])
+
+    def test_end_game_without_processor_does_not_crash(self):
+        # GameManager is still usable in test contexts without a processor
+        self.gm.new_game(self.chat0)
+        self.gm.join_game(self.user0, self.chat0)
+        self.gm.join_game(self.user1, self.chat0)
+        # Should not raise even though update_processor is None
+        self.gm.end_game(self.chat0, self.user0)

--- a/test/test_game_manager.py
+++ b/test/test_game_manager.py
@@ -271,3 +271,36 @@ class TestTopicIsolation(unittest.TestCase):
         outsider = User(777, 'out', is_bot=False)
         # Must not raise
         self.gm.leave_all_games_in_chat(outsider, self.chat)
+
+
+class TestEndGameTaskReference(unittest.TestCase):
+    """jh0ker game_manager.py:167 — keep a strong reference to the
+    ``send_promotion`` task so it can't be garbage-collected mid-flight.
+
+    Reproduces the scenario described in the Python docs for
+    :func:`asyncio.create_task` (Important box)."""
+
+    def test_background_tasks_set_collects_scheduled_tasks(self):
+        import asyncio
+        gm = GameManager()
+        chat = Chat(50, 'group')
+        u0 = User(50, 'u0', is_bot=False)
+        u1 = User(51, 'u1', is_bot=False)
+
+        async def scenario():
+            gm.new_game(chat)
+            gm.join_game(u0, chat)
+            gm.join_game(u1, chat)
+            gm.end_game(chat, u0)
+            # Strong reference must live in a manager-owned collection.
+            assert hasattr(gm, '_background_tasks')
+            # Drain pending tasks so the test loop exits cleanly.
+            pending = [t for t in gm._background_tasks if not t.done()]
+            for t in pending:
+                t.cancel()
+            try:
+                await asyncio.gather(*pending, return_exceptions=True)
+            except Exception:
+                pass
+
+        asyncio.run(scenario())

--- a/test/test_game_manager.py
+++ b/test/test_game_manager.py
@@ -154,8 +154,8 @@ class Test(unittest.TestCase):
         self.gm.update_processor = FakeProcessor()
 
         g = self.gm.new_game(self.chat0, thread_id=11)
-        self.gm.join_game(self.user0, self.chat0)
-        self.gm.join_game(self.user1, self.chat0)
+        self.gm.join_game(self.user0, self.chat0, thread_id=11)
+        self.gm.join_game(self.user1, self.chat0, thread_id=11)
         self.gm.end_game(self.chat0, self.user0)
 
         self.assertEqual(released, [(0, 11)])
@@ -167,3 +167,107 @@ class Test(unittest.TestCase):
         self.gm.join_game(self.user1, self.chat0)
         # Should not raise even though update_processor is None
         self.gm.end_game(self.chat0, self.user0)
+
+
+class TestTopicIsolation(unittest.TestCase):
+    """Cross-topic correctness after the (chat, thread_id) singleton change.
+
+    These tests pin the regressions jh0ker flagged on PR #138:
+    - leave_game / player_for_user_in_chat must be topic-scoped
+    - join_game must not silently fall back to a game in a different topic
+    - status_update (left_chat_member) still needs a way to remove a user
+      from every game in the chat
+    """
+
+    def setUp(self):
+        self.gm = GameManager()
+        self.chat = Chat(10, 'supergroup')
+
+        self.user_a = User(100, 'a', is_bot=False)
+        self.user_b = User(101, 'b', is_bot=False)
+        self.user_c = User(102, 'c', is_bot=False)
+        self.user_d = User(103, 'd', is_bot=False)
+        self.user_e = User(104, 'e', is_bot=False)
+
+        # Two parallel games in the same chat, different topics
+        self.game_main = self.gm.new_game(self.chat)               # (10, None)
+        self.game_topic = self.gm.new_game(self.chat, thread_id=7) # (10, 7)
+
+        # 3 players in each so leave does not trigger NotEnoughPlayersError
+        self.gm.join_game(self.user_a, self.chat, thread_id=None)
+        self.gm.join_game(self.user_d, self.chat, thread_id=None)
+        self.gm.join_game(self.user_c, self.chat, thread_id=None)
+
+        self.gm.join_game(self.user_b, self.chat, thread_id=7)
+        self.gm.join_game(self.user_e, self.chat, thread_id=7)
+        self.gm.join_game(self.user_c, self.chat, thread_id=7)
+        # user_c is now in both games; currently active = topic (last join)
+
+    # jh0ker game_manager.py:83 — no cross-topic fallback in join_game
+    def test_join_game_does_not_fall_back_across_topics(self):
+        new_user = User(999, 'new', is_bot=False)
+        # Try to /join from a topic that has NO game
+        with self.assertRaises(NoGameInChatError):
+            self.gm.join_game(new_user, self.chat, thread_id=42)
+        self.assertNotIn(new_user.id, self.gm.userid_players)
+
+    def test_join_game_from_general_does_not_grab_topic_game(self):
+        # Fresh chat with ONLY a topic game — /join from General must fail
+        gm2 = GameManager()
+        chat = Chat(20, 'supergroup')
+        gm2.new_game(chat, thread_id=5)
+        gm2.join_game(User(1, 'u1', is_bot=False), chat, thread_id=5)
+
+        outsider = User(2, 'out', is_bot=False)
+        with self.assertRaises(NoGameInChatError):
+            gm2.join_game(outsider, chat, thread_id=None)
+        self.assertNotIn(outsider.id, gm2.userid_players)
+
+    # jh0ker game_manager.py:131 — leave_game must respect thread_id
+    def test_leave_game_only_removes_from_specified_topic(self):
+        # user_c is in (10, None) AND (10, 7) — leave from topic only
+        self.gm.leave_game(self.user_c, self.chat, thread_id=7)
+
+        topic_user_ids = {p.user.id for p in self.game_topic.players}
+        main_user_ids = {p.user.id for p in self.game_main.players}
+
+        self.assertNotIn(self.user_c.id, topic_user_ids,
+                         "user_c must leave the topic game")
+        self.assertIn(self.user_c.id, main_user_ids,
+                      "user_c must remain in the main game")
+
+    def test_leave_game_unknown_topic_raises(self):
+        with self.assertRaises(NoGameInChatError):
+            self.gm.leave_game(self.user_a, self.chat, thread_id=999)
+
+    # jh0ker game_manager.py:159 — player_for_user_in_chat must be topic-scoped
+    def test_player_for_user_in_chat_resolves_specific_topic(self):
+        # user_c sits in BOTH games — ask for each topic separately
+        p_main = self.gm.player_for_user_in_chat(self.user_c, self.chat,
+                                                 thread_id=None)
+        p_topic = self.gm.player_for_user_in_chat(self.user_c, self.chat,
+                                                  thread_id=7)
+        self.assertIsNotNone(p_main)
+        self.assertIsNotNone(p_topic)
+        self.assertIs(p_main.game, self.game_main)
+        self.assertIs(p_topic.game, self.game_topic)
+        self.assertIsNot(p_main, p_topic)
+
+    def test_player_for_user_in_chat_unknown_topic_returns_none(self):
+        self.assertIsNone(
+            self.gm.player_for_user_in_chat(self.user_a, self.chat,
+                                             thread_id=999))
+
+    # New helper: status_update needs to remove a user from every game in chat
+    def test_leave_all_games_in_chat_clears_user_from_every_topic(self):
+        self.gm.leave_all_games_in_chat(self.user_c, self.chat)
+
+        main_ids = {p.user.id for p in self.game_main.players}
+        topic_ids = {p.user.id for p in self.game_topic.players}
+        self.assertNotIn(self.user_c.id, main_ids)
+        self.assertNotIn(self.user_c.id, topic_ids)
+
+    def test_leave_all_games_in_chat_is_noop_when_user_not_playing(self):
+        outsider = User(777, 'out', is_bot=False)
+        # Must not raise
+        self.gm.leave_all_games_in_chat(outsider, self.chat)

--- a/test/test_locale.py
+++ b/test/test_locale.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Telegram bot to play UNO in group chats
+# Copyright (c) 2016 Jannes Höke <uno@jhoeke.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+import asyncio
+from contextvars import ContextVar
+import pytest
+
+
+# Replicate the ContextVar mechanism from internationalization.py
+# without importing shared_vars (which requires a valid bot token).
+_locale_stack: ContextVar[list] = ContextVar('test_locale_stack', default=[])
+
+
+class _TestUnderscore:
+    """Minimal reproduction of _Underscore for testing ContextVar isolation"""
+
+    def push(self, locale):
+        stack = _locale_stack.get([])
+        _locale_stack.set(stack + [locale])
+
+    def pop(self):
+        stack = _locale_stack.get([])
+        if stack:
+            locale = stack[-1]
+            _locale_stack.set(stack[:-1])
+            return locale
+        return None
+
+    @property
+    def code(self):
+        stack = _locale_stack.get([])
+        if stack:
+            return stack[-1]
+        return None
+
+    def __call__(self, singular, plural=None, n=1, locale=None):
+        if not locale:
+            stack = _locale_stack.get([])
+            locale = stack[-1] if stack else 'en_US'
+        if n == 1:
+            return singular
+        return plural
+
+
+_ = _TestUnderscore()
+
+
+def set_locale_stack(locales):
+    _locale_stack.set(list(locales))
+
+
+class TestContextVarIsolation:
+    """Tests that locale stack is isolated per asyncio task via ContextVar"""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_tasks_have_isolated_stacks(self):
+        """Two tasks pushing different locales should not interfere"""
+        results = {}
+        barrier = asyncio.Event()
+
+        async def task_a():
+            _.push('de_DE')
+            barrier.set()
+            await asyncio.sleep(0)  # yield to let task_b run
+            results['a'] = _.code
+
+        async def task_b():
+            await barrier.wait()
+            _.push('ru_RU')
+            await asyncio.sleep(0)
+            results['b'] = _.code
+
+        await asyncio.gather(
+            asyncio.create_task(task_a()),
+            asyncio.create_task(task_b()),
+        )
+
+        assert results['a'] == 'de_DE'
+        assert results['b'] == 'ru_RU'
+
+    @pytest.mark.asyncio
+    async def test_main_task_not_affected_by_subtask(self):
+        """A subtask's locale push should not leak into the parent"""
+        _.push('en_US')
+
+        async def subtask():
+            _.push('zh_CN')
+            assert _.code == 'zh_CN'
+
+        await asyncio.create_task(subtask())
+
+        # Parent should still see en_US, not zh_CN
+        assert _.code == 'en_US'
+        _.pop()
+
+    @pytest.mark.asyncio
+    async def test_set_locale_stack_for_jobs(self):
+        """set_locale_stack should replace the current task's stack"""
+        set_locale_stack(['de_DE', 'es_ES'])
+        stack = _locale_stack.get([])
+        assert stack == ['de_DE', 'es_ES']
+        assert _.code == 'es_ES'
+
+    @pytest.mark.asyncio
+    async def test_empty_stack_returns_none(self):
+        """Empty locale stack should return None for code"""
+        _locale_stack.set([])
+        assert _.code is None
+
+    @pytest.mark.asyncio
+    async def test_push_pop_symmetry(self):
+        """Push and pop should be symmetric"""
+        _locale_stack.set([])
+        _.push('de_DE')
+        _.push('fr_FR')
+        assert _.code == 'fr_FR'
+        result = _.pop()
+        assert result == 'fr_FR'
+        assert _.code == 'de_DE'
+        _.pop()
+        assert _.code is None
+
+    @pytest.mark.asyncio
+    async def test_underscore_falls_back_to_en_US(self):
+        """Calling _() with empty stack should use en_US (return original string)"""
+        _locale_stack.set([])
+        result = _("Test string")
+        assert result == "Test string"

--- a/test/test_locale.py
+++ b/test/test_locale.py
@@ -143,3 +143,5 @@ class TestContextVarIsolation:
         _locale_stack.set([])
         result = _("Test string")
         assert result == "Test string"
+
+

--- a/test/test_locale_stack.py
+++ b/test/test_locale_stack.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Telegram bot to play UNO in group chats
+# Copyright (c) 2016 Jannes Höke <uno@jhoeke.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Tests for ``internationalization.locale_stack`` (the real context manager,
+not the in-test replica used by ``test_locale.py``).
+
+``internationalization`` indirectly imports ``shared_vars`` which needs a
+valid bot token, so stub ``config`` before importing."""
+
+import os
+import sys
+import types
+
+# Stub config + DB env before any import of internationalization / shared_vars
+if 'config' not in sys.modules:
+    fake_config = types.ModuleType('config')
+    for k, v in [('TOKEN', '0:abc'), ('WORKERS', 0), ('ADMIN_LIST', []),
+                 ('OPEN_LOBBY', True), ('DEFAULT_GAMEMODE', 'classic'),
+                 ('ENABLE_TRANSLATIONS', False), ('WAITING_TIME', 90),
+                 ('MIN_PLAYERS', 2), ('TIME_REMOVAL_AFTER_SKIP', 20),
+                 ('MIN_FAST_TURN_TIME', 8), ('BOT_USERNAME', 'm')]:
+        setattr(fake_config, k, v)
+    sys.modules['config'] = fake_config
+os.environ.setdefault('UNO_DB', ':memory:')
+
+from internationalization import _locale_stack, locale_stack, set_locale_stack
+
+
+class TestLocaleStackContextManager:
+    """jh0ker internationalization.py:168 — `locale_stack` is a reusable
+    context manager that restores the previous stack on exit."""
+
+    def test_replaces_and_restores(self):
+        _locale_stack.set(['de_DE'])
+        with locale_stack(['fr_FR', 'es_ES']):
+            assert _locale_stack.get([]) == ['fr_FR', 'es_ES']
+        assert _locale_stack.get([]) == ['de_DE']
+
+    def test_restores_on_exception(self):
+        _locale_stack.set(['en_US'])
+        try:
+            with locale_stack(['xx_XX']):
+                raise RuntimeError('boom')
+        except RuntimeError:
+            pass
+        assert _locale_stack.get([]) == ['en_US']
+
+    def test_empty_input_clears_within_block_then_restores(self):
+        _locale_stack.set(['de_DE'])
+        with locale_stack([]):
+            assert _locale_stack.get([]) == []
+        assert _locale_stack.get([]) == ['de_DE']
+
+    def test_nested_blocks_restore_correctly(self):
+        _locale_stack.set(['a'])
+        with locale_stack(['b']):
+            with locale_stack(['c']):
+                assert _locale_stack.get([]) == ['c']
+            assert _locale_stack.get([]) == ['b']
+        assert _locale_stack.get([]) == ['a']
+
+    def test_set_locale_stack_shim_still_works(self):
+        """set_locale_stack is kept as a non-CM shim for callers without a
+        natural with-scope. It must still set the stack directly."""
+        set_locale_stack(['xx_XX', 'yy_YY'])
+        assert _locale_stack.get([]) == ['xx_XX', 'yy_YY']
+        _locale_stack.set([])  # cleanup

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -75,6 +75,7 @@ class Test(unittest.TestCase):
     def test_draw(self):
         p = Player(self.game, "Player 0")
         self.game.start()
+        self.game.draw_counter = 0  # Reset in case first card was DRAW_TWO
 
         deck_before = len(self.game.deck.cards)
         top_card = self.game.deck.cards[-1]

--- a/test/test_result_id.py
+++ b/test/test_result_id.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Telegram bot to play UNO in group chats
+# Copyright (c) 2016 Jannes Höke <uno@jhoeke.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+from result_id import (PSEUDO_GAME_ID, encode_result_id, decode_result_id,
+                       encode_results_list, DecodedResult)
+
+
+class TestEncode:
+    """AC-6: result_id format is <game_id>:<base_id>:<anti_cheat>."""
+
+    def test_encode_card_result(self):
+        rid = encode_result_id(game_id='abc123', base_id='r_5', anti_cheat=3)
+        assert rid == 'abc123:r_5:3'
+
+    def test_encode_action_result(self):
+        rid = encode_result_id(game_id='abc123', base_id='draw', anti_cheat=0)
+        assert rid == 'abc123:draw:0'
+
+    def test_encode_pseudo_game_result(self):
+        rid = encode_result_id(game_id=PSEUDO_GAME_ID, base_id='hand', anti_cheat=0)
+        assert rid == 'none:hand:0'
+
+
+class TestDecode:
+    """AC-7, AC-9: decoder splits cleanly and preserves anti-cheat."""
+
+    def test_decode_card_result(self):
+        d = decode_result_id('abc123:r_5:3')
+        assert d == DecodedResult(game_id='abc123', base_id='r_5', anti_cheat=3)
+
+    def test_decode_color_choice(self):
+        d = decode_result_id('abc123:red:0')
+        assert d.base_id == 'red'
+        assert d.anti_cheat == 0
+
+    def test_decode_pseudo_game(self):
+        d = decode_result_id('none:hand:0')
+        assert d.game_id == PSEUDO_GAME_ID
+        assert d.base_id == 'hand'
+
+    def test_decode_handles_base_id_with_no_extra_colons(self):
+        d = decode_result_id('abc123:mode_classic:0')
+        assert d.base_id == 'mode_classic'
+
+    def test_decode_returns_none_for_old_two_field_format(self):
+        # AC-8: old result IDs (after a bot restart while a game was running)
+        # must not crash — the decoder simply returns None.
+        assert decode_result_id('draw:0') is None
+
+    def test_decode_returns_none_for_garbage(self):
+        assert decode_result_id('garbage') is None
+        assert decode_result_id('') is None
+
+
+class _FakeFrozenResult:
+    """Mimics telegram.InlineQueryResult: id is only writable within _unfrozen()."""
+
+    def __init__(self, id):
+        object.__setattr__(self, '_frozen', False)
+        object.__setattr__(self, 'id', id)
+        object.__setattr__(self, '_frozen', True)
+
+    def __setattr__(self, name, value):
+        if name == 'id' and self._frozen:
+            raise AttributeError(f"Attribute `{name}` can't be set!")
+        object.__setattr__(self, name, value)
+
+    class _Unfrozen:
+        def __init__(self, parent):
+            self.parent = parent
+
+        def __enter__(self):
+            object.__setattr__(self.parent, '_frozen', False)
+            return self.parent
+
+        def __exit__(self, *exc):
+            object.__setattr__(self.parent, '_frozen', True)
+
+    def _unfrozen(self):
+        return _FakeFrozenResult._Unfrozen(self)
+
+
+class TestEncodeResultsList:
+    """AC-6: every result in the list gets the <game_id>:<base_id>:<anti_cheat>
+    encoding — including non-game sentinels."""
+
+    def test_encodes_every_result_in_list(self):
+        results = [_FakeFrozenResult('r_5'), _FakeFrozenResult('draw')]
+
+        encode_results_list(results, game_id='abc123', anti_cheat=3)
+
+        assert results[0].id == 'abc123:r_5:3'
+        assert results[1].id == 'abc123:draw:3'
+
+    def test_encodes_with_pseudo_game_id(self):
+        results = [_FakeFrozenResult('nogame')]
+
+        encode_results_list(results, game_id=PSEUDO_GAME_ID, anti_cheat=0)
+
+        assert results[0].id == 'none:nogame:0'
+
+    def test_encodes_empty_list_is_noop(self):
+        results = []
+        encode_results_list(results, game_id='abc123', anti_cheat=0)
+        assert results == []

--- a/test/test_result_id_resolver.py
+++ b/test/test_result_id_resolver.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Telegram bot to play UNO in group chats
+# Copyright (c) 2016 Jannes Höke <uno@jhoeke.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Tests for resolve_result — the pure helper that maps a decoded inline-result
+ID + user back to the game/player or to a structured "dead-game" outcome that
+the handler can present to the user (AC-8)."""
+
+from types import SimpleNamespace
+
+from result_id import DecodedResult, PSEUDO_GAME_ID
+from result_id_resolver import (DEAD_NO_CURRENT_GAME, DEAD_NOT_A_PLAYER,
+                                DEAD_UNKNOWN_GAME, ResolvedResult,
+                                resolve_result)
+
+
+class _FakeGameManager:
+    def __init__(self, games_by_id=None, userid_current=None):
+        self._by_id = games_by_id or {}
+        self.userid_current = userid_current or {}
+
+    def game_by_id(self, game_id):
+        return self._by_id.get(game_id)
+
+
+def _make_game(game_id):
+    chat = SimpleNamespace(id=42, title='G')
+    return SimpleNamespace(id=game_id, chat=chat, thread_id=None, players=[])
+
+
+def _add_player(game, user_id):
+    user = SimpleNamespace(id=user_id)
+    player = SimpleNamespace(user=user, game=game)
+    game.players.append(player)
+    return player
+
+
+class TestResolveSuccess:
+    def test_pseudo_game_id_returns_user_current_game(self):
+        game = _make_game('g1')
+        player = _add_player(game, 7)
+        gm = _FakeGameManager(userid_current={7: player})
+
+        decoded = DecodedResult(game_id=PSEUDO_GAME_ID, base_id='hand', anti_cheat=0)
+        result = resolve_result(gm, decoded, user_id=7)
+
+        assert isinstance(result, ResolvedResult)
+        assert result.game is game
+        assert result.player is player
+        assert result.dead_reason is None
+
+    def test_real_game_id_returns_game_and_matching_player(self):
+        game = _make_game('abc123')
+        player = _add_player(game, 99)
+        gm = _FakeGameManager(games_by_id={'abc123': game})
+
+        decoded = DecodedResult(game_id='abc123', base_id='r_5', anti_cheat=2)
+        result = resolve_result(gm, decoded, user_id=99)
+
+        assert result.game is game
+        assert result.player is player
+        assert result.dead_reason is None
+
+
+class TestResolveDeadGame:
+    """AC-8: dead-game cases must produce a structured reason."""
+
+    def test_pseudo_id_without_current_game_is_no_current_game(self):
+        gm = _FakeGameManager()
+        decoded = DecodedResult(game_id=PSEUDO_GAME_ID, base_id='mode_classic', anti_cheat=0)
+        result = resolve_result(gm, decoded, user_id=7)
+
+        assert result.game is None
+        assert result.player is None
+        assert result.dead_reason == DEAD_NO_CURRENT_GAME
+
+    def test_real_id_with_unknown_game_is_unknown_game(self):
+        gm = _FakeGameManager(games_by_id={})
+        decoded = DecodedResult(game_id='deadbe', base_id='r_5', anti_cheat=0)
+        result = resolve_result(gm, decoded, user_id=99)
+
+        assert result.dead_reason == DEAD_UNKNOWN_GAME
+
+    def test_real_id_user_not_in_game_is_not_a_player(self):
+        game = _make_game('abc123')
+        # someone else is in this game, but not user 99
+        _add_player(game, 1)
+        gm = _FakeGameManager(games_by_id={'abc123': game})
+
+        decoded = DecodedResult(game_id='abc123', base_id='r_5', anti_cheat=0)
+        result = resolve_result(gm, decoded, user_id=99)
+
+        assert result.dead_reason == DEAD_NOT_A_PLAYER

--- a/test/test_update_processor.py
+++ b/test/test_update_processor.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Telegram bot to play UNO in group chats
+# Copyright (c) 2016 Jannes Höke <uno@jhoeke.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from uno_update_processor import UnoUpdateProcessor
+
+
+def _make_message_update(chat_id, thread_id=None):
+    """Build a minimal Update-like object with .message.chat.id + thread."""
+    return SimpleNamespace(
+        message=SimpleNamespace(
+            chat=SimpleNamespace(id=chat_id),
+            message_thread_id=thread_id,
+        ),
+        edited_message=None,
+        callback_query=None,
+        chosen_inline_result=None,
+        inline_query=None,
+    )
+
+
+def _make_callback_update(chat_id, thread_id=None):
+    return SimpleNamespace(
+        message=None,
+        edited_message=None,
+        callback_query=SimpleNamespace(
+            message=SimpleNamespace(
+                chat=SimpleNamespace(id=chat_id),
+                message_thread_id=thread_id,
+            )
+        ),
+        chosen_inline_result=None,
+        inline_query=None,
+    )
+
+
+def _make_chosen_inline_result_update(result_id):
+    return SimpleNamespace(
+        message=None,
+        edited_message=None,
+        callback_query=None,
+        chosen_inline_result=SimpleNamespace(result_id=result_id),
+        inline_query=None,
+    )
+
+
+def _make_inline_query_update():
+    return SimpleNamespace(
+        message=None,
+        edited_message=None,
+        callback_query=None,
+        chosen_inline_result=None,
+        inline_query=SimpleNamespace(query=''),
+    )
+
+
+class TestKeyExtraction:
+    """AC-11: _key_for_update returns correct (chat_id, thread_id) tuple."""
+
+    def setup_method(self):
+        self.proc = UnoUpdateProcessor(max_concurrent_updates=8)
+
+    def test_message_in_normal_group_returns_chat_none(self):
+        update = _make_message_update(chat_id=123)
+        assert self.proc._key_for_update(update) == (123, None)
+
+    def test_message_in_topic_returns_chat_thread(self):
+        update = _make_message_update(chat_id=123, thread_id=42)
+        assert self.proc._key_for_update(update) == (123, 42)
+
+    def test_callback_query_returns_chat_thread(self):
+        update = _make_callback_update(chat_id=999, thread_id=7)
+        assert self.proc._key_for_update(update) == (999, 7)
+
+    def test_chosen_inline_result_extracts_chat_thread_from_result_id(self):
+        # Format: <game_id>:<base_id>:<anti_cheat>
+        # We don't decode chat/thread directly — we look it up via game registry.
+        # The processor accepts a resolver callback for that purpose.
+        resolver = MagicMock(return_value=(555, 3))
+        proc = UnoUpdateProcessor(max_concurrent_updates=8, game_resolver=resolver)
+        update = _make_chosen_inline_result_update(result_id='abc123:r_5:0')
+        assert proc._key_for_update(update) == (555, 3)
+        resolver.assert_called_once_with('abc123')
+
+    def test_chosen_inline_result_unknown_game_returns_none(self):
+        resolver = MagicMock(return_value=None)
+        proc = UnoUpdateProcessor(max_concurrent_updates=8, game_resolver=resolver)
+        update = _make_chosen_inline_result_update(result_id='deadbe:r_5:0')
+        assert proc._key_for_update(update) is None
+
+    def test_chosen_inline_result_pseudo_game_id_returns_none(self):
+        resolver = MagicMock()
+        proc = UnoUpdateProcessor(max_concurrent_updates=8, game_resolver=resolver)
+        update = _make_chosen_inline_result_update(result_id='none:hand:0')
+        assert proc._key_for_update(update) is None
+        resolver.assert_not_called()
+
+    def test_inline_query_returns_none(self):
+        update = _make_inline_query_update()
+        assert self.proc._key_for_update(update) is None
+
+    def test_malformed_result_id_returns_none(self):
+        proc = UnoUpdateProcessor(max_concurrent_updates=8, game_resolver=MagicMock())
+        update = _make_chosen_inline_result_update(result_id='garbage')
+        assert proc._key_for_update(update) is None
+
+
+class TestSerialization:
+    """AC-12, AC-17: same key -> serial; different keys -> parallel."""
+
+    def setup_method(self):
+        self.proc = UnoUpdateProcessor(max_concurrent_updates=8)
+
+    @pytest.mark.asyncio
+    async def test_same_key_updates_run_serially(self):
+        running = []
+        peak_concurrent = [0]
+
+        async def coro():
+            running.append(1)
+            peak_concurrent[0] = max(peak_concurrent[0], len(running))
+            await asyncio.sleep(0.05)
+            running.pop()
+
+        update1 = _make_message_update(chat_id=1)
+        update2 = _make_message_update(chat_id=1)
+
+        await self.proc.initialize()
+        try:
+            await asyncio.gather(
+                self.proc.do_process_update(update1, coro()),
+                self.proc.do_process_update(update2, coro()),
+            )
+        finally:
+            await self.proc.shutdown()
+
+        assert peak_concurrent[0] == 1, "same-key updates must serialize"
+
+    @pytest.mark.asyncio
+    async def test_different_keys_run_in_parallel(self):
+        running = []
+        peak_concurrent = [0]
+
+        async def coro():
+            running.append(1)
+            peak_concurrent[0] = max(peak_concurrent[0], len(running))
+            await asyncio.sleep(0.05)
+            running.pop()
+
+        update1 = _make_message_update(chat_id=1)
+        update2 = _make_message_update(chat_id=2)
+        update3 = _make_message_update(chat_id=1, thread_id=7)
+
+        await self.proc.initialize()
+        try:
+            await asyncio.gather(
+                self.proc.do_process_update(update1, coro()),
+                self.proc.do_process_update(update2, coro()),
+                self.proc.do_process_update(update3, coro()),
+            )
+        finally:
+            await self.proc.shutdown()
+
+        assert peak_concurrent[0] == 3, "different keys must run in parallel"
+
+    @pytest.mark.asyncio
+    async def test_unkeyed_update_runs_without_lock(self):
+        # AC-14: inline queries must never block on a per-chat lock
+        running_inline = []
+        peak_inline = [0]
+
+        async def inline_coro():
+            running_inline.append(1)
+            peak_inline[0] = max(peak_inline[0], len(running_inline))
+            await asyncio.sleep(0.05)
+            running_inline.pop()
+
+        update_a = _make_inline_query_update()
+        update_b = _make_inline_query_update()
+        update_c = _make_inline_query_update()
+
+        await self.proc.initialize()
+        try:
+            await asyncio.gather(
+                self.proc.do_process_update(update_a, inline_coro()),
+                self.proc.do_process_update(update_b, inline_coro()),
+                self.proc.do_process_update(update_c, inline_coro()),
+            )
+        finally:
+            await self.proc.shutdown()
+
+        assert peak_inline[0] == 3, "inline queries must never serialize"
+
+
+class TestLifecycle:
+    """AC-10: initialize/shutdown succeed without errors."""
+
+    @pytest.mark.asyncio
+    async def test_initialize_and_shutdown_are_noop_safe(self):
+        proc = UnoUpdateProcessor(max_concurrent_updates=4)
+        await proc.initialize()
+        await proc.shutdown()
+
+    def test_release_key_removes_lock(self):
+        proc = UnoUpdateProcessor(max_concurrent_updates=4)
+        # populate via a sync access to lock dict
+        proc._lock_for_key((1, None))
+        assert (1, None) in proc._locks
+        proc.release_key((1, None))
+        assert (1, None) not in proc._locks
+
+    def test_release_unknown_key_is_noop(self):
+        proc = UnoUpdateProcessor(max_concurrent_updates=4)
+        proc.release_key((999, None))  # must not raise

--- a/test/test_update_processor.py
+++ b/test/test_update_processor.py
@@ -28,31 +28,33 @@ from uno_update_processor import UnoUpdateProcessor
 
 
 def _make_message_update(chat_id, thread_id=None):
-    """Build a minimal Update-like object with .message.chat.id + thread."""
+    """Build a minimal Update-like object with .effective_message set."""
+    msg = SimpleNamespace(
+        chat=SimpleNamespace(id=chat_id),
+        message_thread_id=thread_id,
+    )
     return SimpleNamespace(
-        message=SimpleNamespace(
-            chat=SimpleNamespace(id=chat_id),
-            message_thread_id=thread_id,
-        ),
+        message=msg,
         edited_message=None,
         callback_query=None,
         chosen_inline_result=None,
         inline_query=None,
+        effective_message=msg,
     )
 
 
 def _make_callback_update(chat_id, thread_id=None):
+    msg = SimpleNamespace(
+        chat=SimpleNamespace(id=chat_id),
+        message_thread_id=thread_id,
+    )
     return SimpleNamespace(
         message=None,
         edited_message=None,
-        callback_query=SimpleNamespace(
-            message=SimpleNamespace(
-                chat=SimpleNamespace(id=chat_id),
-                message_thread_id=thread_id,
-            )
-        ),
+        callback_query=SimpleNamespace(message=msg),
         chosen_inline_result=None,
         inline_query=None,
+        effective_message=msg,
     )
 
 
@@ -63,6 +65,7 @@ def _make_chosen_inline_result_update(result_id):
         callback_query=None,
         chosen_inline_result=SimpleNamespace(result_id=result_id),
         inline_query=None,
+        effective_message=None,
     )
 
 
@@ -73,6 +76,7 @@ def _make_inline_query_update():
         callback_query=None,
         chosen_inline_result=None,
         inline_query=SimpleNamespace(query=''),
+        effective_message=None,
     )
 
 

--- a/test/test_update_processor.py
+++ b/test/test_update_processor.py
@@ -234,3 +234,48 @@ class TestLifecycle:
     def test_release_unknown_key_is_noop(self):
         proc = UnoUpdateProcessor(max_concurrent_updates=4)
         proc.release_key((999, None))  # must not raise
+
+    def test_lock_for_key_is_public_and_idempotent(self):
+        """Background tasks (job_queue) need a way to grab the same lock the
+        processor uses for inline updates of the same game."""
+        proc = UnoUpdateProcessor(max_concurrent_updates=4)
+        lock_a = proc.lock_for_key((1, None))
+        lock_b = proc.lock_for_key((1, None))
+        lock_c = proc.lock_for_key((1, 7))
+        assert lock_a is lock_b
+        assert lock_a is not lock_c
+
+
+class TestBackgroundTaskSerialization:
+    """A job_queue callback must contend with concurrent inline updates for
+    the same game when it grabs ``lock_for_key``."""
+
+    @pytest.mark.asyncio
+    async def test_lock_serializes_background_task_with_update(self):
+        import asyncio
+        proc = UnoUpdateProcessor(max_concurrent_updates=4)
+        running = []
+        peak = [0]
+
+        async def work():
+            running.append(1)
+            peak[0] = max(peak[0], len(running))
+            await asyncio.sleep(0.05)
+            running.pop()
+
+        async def background():
+            async with proc.lock_for_key((1, None)):
+                await work()
+
+        update = _make_message_update(chat_id=1)
+
+        await proc.initialize()
+        try:
+            await asyncio.gather(
+                proc.do_process_update(update, work()),
+                background(),
+            )
+        finally:
+            await proc.shutdown()
+
+        assert peak[0] == 1, "background task must serialize with same-key updates"

--- a/uno_update_processor.py
+++ b/uno_update_processor.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Telegram bot to play UNO in group chats
+# Copyright (c) 2016 Jannes Höke <uno@jhoeke.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Custom UpdateProcessor that serializes updates per (chat_id, thread_id)."""
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, Optional, Tuple
+
+from telegram import Update
+from telegram.ext import BaseUpdateProcessor
+
+
+logger = logging.getLogger(__name__)
+
+
+GameKey = Tuple[int, Optional[int]]
+GameResolver = Callable[[str], Optional[GameKey]]
+
+
+class UnoUpdateProcessor(BaseUpdateProcessor):
+    """Serializes updates that target the same (chat_id, thread_id).
+
+    Inline queries and other updates without a derivable chat context run in
+    parallel. ``ChosenInlineResult`` updates carry the game id in their
+    ``result_id`` (format: ``<game_id>:<base_id>:<anti_cheat>``); the optional
+    ``game_resolver`` callback maps that game id back to a ``(chat_id,
+    thread_id)`` key.
+    """
+
+    def __init__(self, max_concurrent_updates: int,
+                 game_resolver: Optional[GameResolver] = None):
+        super().__init__(max_concurrent_updates=max_concurrent_updates)
+        self._locks: dict[GameKey, asyncio.Lock] = {}
+        self._game_resolver = game_resolver
+
+    def _lock_for_key(self, key: GameKey) -> asyncio.Lock:
+        lock = self._locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[key] = lock
+        return lock
+
+    def release_key(self, key: GameKey) -> None:
+        """Drop the lock for a key once its game has ended."""
+        self._locks.pop(key, None)
+
+    def _key_for_update(self, update) -> Optional[GameKey]:
+        msg = getattr(update, 'message', None) or getattr(update, 'edited_message', None)
+        if msg is not None:
+            chat = getattr(msg, 'chat', None)
+            if chat is not None:
+                return (chat.id, getattr(msg, 'message_thread_id', None))
+
+        cb = getattr(update, 'callback_query', None)
+        if cb is not None:
+            cb_msg = getattr(cb, 'message', None)
+            if cb_msg is not None:
+                chat = getattr(cb_msg, 'chat', None)
+                if chat is not None:
+                    return (chat.id, getattr(cb_msg, 'message_thread_id', None))
+
+        cir = getattr(update, 'chosen_inline_result', None)
+        if cir is not None and self._game_resolver is not None:
+            result_id = getattr(cir, 'result_id', '') or ''
+            parts = result_id.split(':', 2)
+            if len(parts) < 3:
+                return None
+            game_id = parts[0]
+            if game_id == 'none':
+                return None
+            return self._game_resolver(game_id)
+
+        return None
+
+    async def do_process_update(self, update: Update,
+                                coroutine: Awaitable[None]) -> None:
+        key = self._key_for_update(update)
+        if key is None:
+            await coroutine
+            return
+
+        lock = self._lock_for_key(key)
+        async with lock:
+            await coroutine
+
+    async def initialize(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        self._locks.clear()

--- a/uno_update_processor.py
+++ b/uno_update_processor.py
@@ -73,23 +73,15 @@ class UnoUpdateProcessor(BaseUpdateProcessor):
         self._locks.pop(key, None)
 
     def _key_for_update(self, update) -> Optional[GameKey]:
-        msg = getattr(update, 'message', None) or getattr(update, 'edited_message', None)
-        if msg is not None:
-            chat = getattr(msg, 'chat', None)
-            if chat is not None:
-                return (chat.id, getattr(msg, 'message_thread_id', None))
+        # update.effective_message covers Message, EditedMessage and the
+        # CallbackQuery.message case in a single attribute lookup.
+        msg = update.effective_message
+        if msg is not None and msg.chat is not None:
+            return (msg.chat.id, msg.message_thread_id)
 
-        cb = getattr(update, 'callback_query', None)
-        if cb is not None:
-            cb_msg = getattr(cb, 'message', None)
-            if cb_msg is not None:
-                chat = getattr(cb_msg, 'chat', None)
-                if chat is not None:
-                    return (chat.id, getattr(cb_msg, 'message_thread_id', None))
-
-        cir = getattr(update, 'chosen_inline_result', None)
+        cir = update.chosen_inline_result
         if cir is not None and self._game_resolver is not None:
-            result_id = getattr(cir, 'result_id', '') or ''
+            result_id = cir.result_id or ''
             parts = result_id.split(':', 2)
             if len(parts) < 3:
                 return None

--- a/uno_update_processor.py
+++ b/uno_update_processor.py
@@ -51,12 +51,22 @@ class UnoUpdateProcessor(BaseUpdateProcessor):
         self._locks: dict[GameKey, asyncio.Lock] = {}
         self._game_resolver = game_resolver
 
-    def _lock_for_key(self, key: GameKey) -> asyncio.Lock:
+    def lock_for_key(self, key: GameKey) -> asyncio.Lock:
+        """Return the ``asyncio.Lock`` for ``key``, creating one if needed.
+
+        Public so that background tasks (e.g. ``actions.skip_job`` fired by
+        the job queue) can serialise themselves against concurrent inline
+        updates targeting the same game.
+        """
         lock = self._locks.get(key)
         if lock is None:
             lock = asyncio.Lock()
             self._locks[key] = lock
         return lock
+
+    # Internal alias kept so existing call sites in ``do_process_update`` and
+    # the legacy test suite don't need to learn the new name.
+    _lock_for_key = lock_for_key
 
     def release_key(self, key: GameKey) -> None:
         """Drop the lock for a key once its game has ended."""

--- a/utils.py
+++ b/utils.py
@@ -90,6 +90,8 @@ async def send_async(bot, *args, **kwargs):
     """Send a message asynchronously"""
     if 'read_timeout' not in kwargs:
         kwargs['read_timeout'] = TIMEOUT
+    if 'write_timeout' not in kwargs:
+        kwargs['write_timeout'] = TIMEOUT
 
     try:
         await bot.send_message(*args, **kwargs)
@@ -101,6 +103,8 @@ async def answer_async(bot, *args, **kwargs):
     """Answer an inline query asynchronously"""
     if 'read_timeout' not in kwargs:
         kwargs['read_timeout'] = TIMEOUT
+    if 'write_timeout' not in kwargs:
+        kwargs['write_timeout'] = TIMEOUT
 
     try:
         await bot.answer_inline_query(*args, **kwargs)

--- a/utils.py
+++ b/utils.py
@@ -88,8 +88,8 @@ async def error(update: object, context: ContextTypes.DEFAULT_TYPE):
 
 async def send_async(bot, *args, **kwargs):
     """Send a message asynchronously"""
-    if 'timeout' not in kwargs:
-        kwargs['timeout'] = TIMEOUT
+    if 'read_timeout' not in kwargs:
+        kwargs['read_timeout'] = TIMEOUT
 
     try:
         await bot.send_message(*args, **kwargs)
@@ -99,8 +99,8 @@ async def send_async(bot, *args, **kwargs):
 
 async def answer_async(bot, *args, **kwargs):
     """Answer an inline query asynchronously"""
-    if 'timeout' not in kwargs:
-        kwargs['timeout'] = TIMEOUT
+    if 'read_timeout' not in kwargs:
+        kwargs['read_timeout'] = TIMEOUT
 
     try:
         await bot.answer_inline_query(*args, **kwargs)

--- a/utils.py
+++ b/utils.py
@@ -19,16 +19,20 @@
 
 
 import logging
+import time
+
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ContextTypes
 
 from internationalization import _, __
-from mwt import MWT
-from shared_vars import gm, dispatcher
+from shared_vars import gm
 
 logger = logging.getLogger(__name__)
 
 TIMEOUT = 2.5
+
+_admin_cache = {}
+_admin_cache_timeout = 60 * 60
 
 
 def list_subtract(list1, list2):
@@ -77,31 +81,31 @@ def display_color_group(color, game):
             emoji='💛')
 
 
-def error(update: Update, context: CallbackContext):
+async def error(update: object, context: ContextTypes.DEFAULT_TYPE):
     """Simple error handler"""
     logger.exception(context.error)
 
 
-def send_async(bot, *args, **kwargs):
+async def send_async(bot, *args, **kwargs):
     """Send a message asynchronously"""
     if 'timeout' not in kwargs:
         kwargs['timeout'] = TIMEOUT
 
     try:
-        dispatcher.run_async(bot.sendMessage, *args, **kwargs)
+        await bot.send_message(*args, **kwargs)
     except Exception as e:
-        error(None, None, e)
+        logger.exception(e)
 
 
-def answer_async(bot, *args, **kwargs):
+async def answer_async(bot, *args, **kwargs):
     """Answer an inline query asynchronously"""
     if 'timeout' not in kwargs:
         kwargs['timeout'] = TIMEOUT
 
     try:
-        dispatcher.run_async(bot.answerInlineQuery, *args, **kwargs)
+        await bot.answer_inline_query(*args, **kwargs)
     except Exception as e:
-        error(None, None, e)
+        logger.exception(e)
 
 
 def game_is_running(game):
@@ -112,15 +116,23 @@ def user_is_creator(user, game):
     return user.id in game.owner
 
 
-def user_is_admin(user, bot, chat):
-    return user.id in get_admin_ids(bot, chat.id)
+async def user_is_creator_or_admin(user, game, bot, chat):
+    return user_is_creator(user, game) or await user_is_admin(bot, chat, user)
 
 
-def user_is_creator_or_admin(user, game, bot, chat):
-    return user_is_creator(user, game) or user_is_admin(user, bot, chat)
+async def user_is_admin(bot, chat, user):
+    admin_ids = await get_admin_ids(bot, chat.id)
+    return user.id in admin_ids
 
 
-@MWT(timeout=60*60)
-def get_admin_ids(bot, chat_id):
+async def get_admin_ids(bot, chat_id):
     """Returns a list of admin IDs for a given chat. Results are cached for 1 hour."""
-    return [admin.user.id for admin in bot.get_chat_administrators(chat_id)]
+    now = time.time()
+    if chat_id in _admin_cache:
+        ids, timestamp = _admin_cache[chat_id]
+        if now - timestamp < _admin_cache_timeout:
+            return ids
+    admins = await bot.get_chat_administrators(chat_id)
+    ids = [admin.user.id for admin in admins]
+    _admin_cache[chat_id] = (ids, now)
+    return ids

--- a/utils.py
+++ b/utils.py
@@ -29,8 +29,6 @@ from shared_vars import gm
 
 logger = logging.getLogger(__name__)
 
-TIMEOUT = 2.5
-
 _admin_cache = {}
 _admin_cache_timeout = 60 * 60
 
@@ -87,12 +85,9 @@ async def error(update: object, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def send_async(bot, *args, **kwargs):
-    """Send a message asynchronously"""
-    if 'read_timeout' not in kwargs:
-        kwargs['read_timeout'] = TIMEOUT
-    if 'write_timeout' not in kwargs:
-        kwargs['write_timeout'] = TIMEOUT
-
+    """Send a message, swallowing exceptions so a failed send does not crash
+    the calling handler. Network timeouts are configured centrally on the
+    Application builder (see ``shared_vars.py``)."""
     try:
         await bot.send_message(*args, **kwargs)
     except Exception as e:
@@ -100,12 +95,8 @@ async def send_async(bot, *args, **kwargs):
 
 
 async def answer_async(bot, *args, **kwargs):
-    """Answer an inline query asynchronously"""
-    if 'read_timeout' not in kwargs:
-        kwargs['read_timeout'] = TIMEOUT
-    if 'write_timeout' not in kwargs:
-        kwargs['write_timeout'] = TIMEOUT
-
+    """Answer an inline query, swallowing exceptions for the same reason as
+    :func:`send_async`."""
     try:
         await bot.answer_inline_query(*args, **kwargs)
     except Exception as e:

--- a/utils.py
+++ b/utils.py
@@ -113,7 +113,7 @@ async def answer_async(bot, *args, **kwargs):
 
 
 def game_is_running(game):
-    return game in gm.chatid_games.get(game.chat.id, list())
+    return gm.games_by_id.get(game.id) is game
 
 
 def user_is_creator(user, game):

--- a/utils.py
+++ b/utils.py
@@ -80,8 +80,18 @@ def display_color_group(color, game):
 
 
 async def error(update: object, context: ContextTypes.DEFAULT_TYPE):
-    """Simple error handler"""
-    logger.exception(context.error)
+    """Log the exception PTB caught.
+
+    Uses ``exc_info=`` so the real traceback is attached: ``logger.exception``
+    only walks the active exception context (``sys.exc_info()``), which is
+    empty here because this handler runs after PTB has already swallowed
+    the exception.
+    """
+    exc = getattr(context, 'error', None) if context is not None else None
+    if exc is not None:
+        logger.error("Unhandled exception in update handler", exc_info=exc)
+    else:
+        logger.error("Error handler invoked without context.error")
 
 
 async def send_async(bot, *args, **kwargs):


### PR DESCRIPTION
## Summary

Complete migration from python-telegram-bot **v13** (sync) to **v22.7** (async), addressing all concerns raised in #136, plus forum topic support, gameplay fixes from real playtesting, and a follow-up refactor that consolidates concurrency behind a custom UpdateProcessor.

### v22 Migration
- **Async API**: All handlers → `async def`, `Updater`/`Dispatcher` → `Application.builder()`, `dispatcher.run_async()` → native `await`
- **Locale isolation**: `contextvars.ContextVar` replaces the global locale stack, exposed as a `locale_stack()` context manager that both `@game_locales` and `skip_job` enter
- **v22 API fixes**: `read_timeout`/`write_timeout`/`connect_timeout` configured on the `ApplicationBuilder`, `with db_session:` blocks outside `await`, `InlineQueryResultsButton`, `_unfrozen()` for frozen result objects, `asyncio.get_running_loop()`
- **Input validation**: callback query data validated, gamemode whitelist, `Game.owner` moved to instance attribute, startup token + admin-list checks
- **Error handler**: `error()` now uses `exc_info=context.error` so the real traceback is attached instead of an empty `sys.exc_info()`

### Concurrency — Custom UpdateProcessor
Locking is centralised in `UnoUpdateProcessor` (`telegram.ext.BaseUpdateProcessor` subclass) which holds a `dict[(chat_id, thread_id), asyncio.Lock]`. Updates that target the same `(chat, topic)` are serialised; updates for different `(chat, topic)` or without a derivable chat (inline queries) run in parallel.

- Singleton model: at most one active `Game` per `(chat_id, thread_id)`. `GameManager.new_game` raises `GameAlreadyRunningError` when the topic is busy.
- `ChosenInlineResult` updates carry the encoded `<game_id>:<base_id>:<anti_cheat>` in their `result_id`; the processor maps `game_id` back to a key via a resolver callback.
- All public `GameManager` lookups (`leave_game`, `player_for_user_in_chat`, `_games_in_chat`) take an explicit `thread_id` — no cross-topic fallback. New `leave_all_games_in_chat` handles the `left_chat_member` case.
- Background tasks (`skip_job`, `send_promotion`) acquire the same lock via `update_processor.lock_for_key(key)` and keep a strong reference via `_background_tasks`.
- Per-handler `async with chat_lock` / `async with game.lock` blocks are gone. `Game.lock` and `GameManager.chat_locks` are removed.

### Forum Topic Support
- Bot replies land in the correct forum topic (`Game.thread_id` set on `/new`)
- Promotions include `message_thread_id` for forum correctness
- Works in normal groups (ignored), forum groups (correct topic), and private chats
- Dead-game inline results (game ended between `answer_inline_query` and `chosen_inline_result`) DM the player a friendly hint instead of silently dropping the selection

### Gameplay Fixes (from real two-player testing)
- `join_game`: responses go to the game's topic, not sender's topic
- Inline query: defensive draw icon for next player during turn transitions
- `reset_waiting_time` is async and re-emits the chat notification that was lost during the v22 port

### Quality of Life
- `set_my_commands()` on startup — command menu auto-registers
- Startup validation: warns if inline mode not enabled, exits on missing token / bad admin list
- `python-telegram-bot[ext,http2]` brings `AIORateLimiter` (available for future wiring) and HTTP/2 in the httpx client
- `.github/copilot-instructions.md` describes the new locking model so automated reviews don't suggest re-introducing per-Game locks

### Relation to #136
Adopts the design jh0ker suggested in the #136 review: custom UpdateProcessor, single game per `(chat, topic)`, `ContextVar` locale stack, `with db_session:` blocks for Pony ORM + async.

### Changes

| Layer | Files | What changed |
|-------|-------|-------------|
| Bootstrap | `shared_vars.py`, `start_bot.py` | `Application.builder()` + `UnoUpdateProcessor(256)`, builder-level timeouts |
| Concurrency | `uno_update_processor.py` (new) | `BaseUpdateProcessor` subclass, public `lock_for_key` |
| Result IDs | `result_id.py`, `result_id_resolver.py` (new) | Encode `<game_id>:<base_id>:<anti_cheat>`, dead-game resolution |
| Infrastructure | `utils.py`, `internationalization.py` | Async helpers, `locale_stack` CM, `error()` with `exc_info=` |
| Game logic | `actions.py`, `promotions.py`, `game.py`, `game_manager.py`, `errors.py` | Async, `thread_id`-aware API, `GameAlreadyRunningError`, strong-ref background tasks |
| Handlers | `bot.py`, `simple_commands.py`, `settings.py` | Async, `filters.*`, forum support, startup validation |
| Config | `config.py`, `requirements.txt`, `Pipfile` | Token validation, `python-telegram-bot[ext,http2]==22.7` |
| Tests | `test/test_*` (8 modules) | 77 tests covering processor, result IDs, resolver, topic isolation, locks-removed pin |
| Docs | `.github/copilot-instructions.md`, `locales/unobot.pot` | New locking model, new translatable strings |

## Test plan

- [x] 77/77 unit tests pass
- [x] Docker build succeeds
- [x] Bot starts with real token
- [x] `/help` in private chat and forum topic
- [x] `/new`, `/join`, `/start` in forum topic
- [x] Inline query shows cards ("Make your choice!")
- [x] Card play, draw, pass, UNO call all work
- [x] Auto-skip timer counts down
- [x] Full game to completion (win + "Game ended!")
- [x] Bot commands appear in Telegram menu
- [x] Startup warns if inline mode disabled

### Known pre-existing issues (not introduced by this PR)
- `kb_select` / `locale_select` in `settings.py`: `UserSetting.get()` can return `None` (confirmed pre-existing by jh0ker)
